### PR TITLE
Add service type support for CLI tools

### DIFF
--- a/Updaemon.Tests/Commands/InitCommandTests.cs
+++ b/Updaemon.Tests/Commands/InitCommandTests.cs
@@ -17,12 +17,15 @@ namespace Updaemon.Tests.Commands
             public MockOutputWriter OutputWriter { get; } = new MockOutputWriter();
             public MockUnitFileManager UnitFileManager { get; } = new MockUnitFileManager();
             public MockServiceDeployer ServiceDeployer { get; } = new MockServiceDeployer();
+            public MockSymlinkManager SymlinkManager { get; } = new MockSymlinkManager();
             public TempFileHelper TempHelper { get; } = new TempFileHelper();
             public string SystemdDirectory { get; }
+            public string BinDirectory { get; }
 
             public InitCommandTestBuilder()
             {
                 SystemdDirectory = TempHelper.CreateTempDirectory("systemd");
+                BinDirectory = TempHelper.CreateTempDirectory("bin");
                 ServiceDeployer.ServiceBaseDirectory = TempHelper.TempDirectory;
             }
 
@@ -31,7 +34,7 @@ namespace Updaemon.Tests.Commands
                 return new InitCommand(
                     ConfigManager, SecretsManager, ServiceManager,
                     DistributionClient, OutputWriter, UnitFileManager,
-                    ServiceDeployer, SystemdDirectory);
+                    ServiceDeployer, SymlinkManager, SystemdDirectory, BinDirectory);
             }
 
             /// <summary>
@@ -46,6 +49,20 @@ namespace Updaemon.Tests.Commands
                 InstalledPluginInfo pluginInfo = new InstalledPluginInfo { Alias = pluginAlias, Path = pluginPath };
                 await ConfigManager.AddOrUpdatePluginAsync(pluginInfo);
                 await ConfigManager.RegisterServiceAsync(localName, remoteName, pluginAlias);
+            }
+
+            /// <summary>
+            /// Registers a CLI tool with a valid plugin so the command passes validation.
+            /// </summary>
+            public async Task RegisterCliToolWithPluginAsync(
+                string localName = "my-tool",
+                string remoteName = "owner/tool",
+                string pluginAlias = "github")
+            {
+                string pluginPath = TempHelper.CreateTempFile("plugin/github-dist", "fake-plugin");
+                InstalledPluginInfo pluginInfo = new InstalledPluginInfo { Alias = pluginAlias, Path = pluginPath };
+                await ConfigManager.AddOrUpdatePluginAsync(pluginInfo);
+                await ConfigManager.RegisterServiceAsync(localName, remoteName, pluginAlias, ServiceType.Cli);
             }
 
             public void Dispose()
@@ -202,7 +219,7 @@ namespace Updaemon.Tests.Commands
                 InitCommand command = new InitCommand(
                     b.ConfigManager, b.SecretsManager, b.ServiceManager,
                     b.DistributionClient, b.OutputWriter, capturingManager,
-                    b.ServiceDeployer, b.SystemdDirectory);
+                    b.ServiceDeployer, b.SymlinkManager, b.SystemdDirectory, b.BinDirectory);
 
                 int exitCode = await command.ExecuteAsync(new[] { "my-api" });
 
@@ -231,6 +248,98 @@ namespace Updaemon.Tests.Commands
                 // Should have called cleanup on the deployer
                 Assert.Contains(b.ServiceDeployer.MethodCalls, c => c.StartsWith("CleanupDeployAsync:"));
                 Assert.Single(b.ServiceDeployer.CleanedUpDeploys);
+            }
+        }
+
+        [Fact]
+        public async Task ExecuteAsync_CliTool_HappyPath_CreatesBothSymlinks()
+        {
+            using (InitCommandTestBuilder b = new InitCommandTestBuilder())
+            {
+                await b.RegisterCliToolWithPluginAsync(localName: "rg", remoteName: "BurntSushi/ripgrep");
+
+                b.DistributionClient.SetLatestVersion("BurntSushi/ripgrep", new Version(1, 0, 0));
+                b.ServiceDeployer.SetDeployResult("rg", new Version(1, 0, 0), "ripgrep");
+
+                InitCommand command = b.Build();
+                int exitCode = await command.ExecuteAsync(new[] { "rg" });
+
+                Assert.Equal(0, exitCode);
+                Assert.Contains(b.ServiceDeployer.MethodCalls, c => c == "DeployVersionAsync:rg:1.0.0");
+
+                // Should have created a bin symlink with the executable name
+                string expectedBinPath = Path.Combine(b.BinDirectory, "ripgrep");
+                Assert.Contains(b.SymlinkManager.Symlinks, kv => kv.Key == expectedBinPath);
+
+                // Should also have created an alias symlink with the local name
+                string expectedAliasPath = Path.Combine(b.BinDirectory, "rg");
+                Assert.Contains(b.SymlinkManager.Symlinks, kv => kv.Key == expectedAliasPath);
+
+                Assert.Contains(b.OutputWriter.Messages, m => m.Contains("CLI tool") && m.Contains("initialized successfully"));
+                Assert.True(b.DistributionClient.IsDisposed);
+            }
+        }
+
+        [Fact]
+        public async Task ExecuteAsync_CliTool_SameLocalAndExecutableName_CreatesSingleSymlink()
+        {
+            using (InitCommandTestBuilder b = new InitCommandTestBuilder())
+            {
+                await b.RegisterCliToolWithPluginAsync();
+
+                b.DistributionClient.SetLatestVersion("owner/tool", new Version(1, 0, 0));
+                b.ServiceDeployer.SetDeployResult("my-tool", new Version(1, 0, 0), "my-tool");
+
+                InitCommand command = b.Build();
+                int exitCode = await command.ExecuteAsync(new[] { "my-tool" });
+
+                Assert.Equal(0, exitCode);
+
+                // Only one symlink should exist since local name matches executable name
+                string expectedBinPath = Path.Combine(b.BinDirectory, "my-tool");
+                Assert.Single(b.SymlinkManager.Symlinks);
+                Assert.Contains(b.SymlinkManager.Symlinks, kv => kv.Key == expectedBinPath);
+            }
+        }
+
+        [Fact]
+        public async Task ExecuteAsync_CliTool_SkipsSystemdSetup()
+        {
+            using (InitCommandTestBuilder b = new InitCommandTestBuilder())
+            {
+                await b.RegisterCliToolWithPluginAsync(localName: "my-tool", remoteName: "owner/tool");
+
+                b.DistributionClient.SetLatestVersion("owner/tool", new Version(1, 0, 0));
+                b.ServiceDeployer.SetDeployResult("my-tool", new Version(1, 0, 0), "my-tool");
+
+                InitCommand command = b.Build();
+                int exitCode = await command.ExecuteAsync(new[] { "my-tool" });
+
+                Assert.Equal(0, exitCode);
+
+                // No systemd calls should have been made
+                Assert.DoesNotContain(b.ServiceManager.MethodCalls, c => c == "DaemonReloadAsync");
+                Assert.DoesNotContain(b.ServiceManager.MethodCalls, c => c.StartsWith("EnableServiceAsync"));
+                Assert.DoesNotContain(b.ServiceManager.MethodCalls, c => c.StartsWith("StartServiceAsync"));
+
+                // No unit file should exist
+                Assert.False(File.Exists(Path.Combine(b.SystemdDirectory, "my-tool.service")));
+            }
+        }
+
+        [Fact]
+        public async Task ExecuteAsync_CliTool_AlreadyInitialized_ReturnsSuccessWithMessage()
+        {
+            using (InitCommandTestBuilder b = new InitCommandTestBuilder())
+            {
+                await b.RegisterCliToolWithPluginAsync();
+                b.ServiceDeployer.SetInitialized("my-tool", "/opt/my-tool/1.0.0");
+
+                InitCommand command = b.Build();
+                int exitCode = await command.ExecuteAsync(new[] { "my-tool" });
+
+                Assert.Equal(0, exitCode);
+                Assert.Contains(b.OutputWriter.Messages, m => m.Contains("CLI tool") && m.Contains("already initialized"));
             }
         }
 

--- a/Updaemon.Tests/Commands/InitCommandTests.cs
+++ b/Updaemon.Tests/Commands/InitCommandTests.cs
@@ -343,6 +343,56 @@ namespace Updaemon.Tests.Commands
             }
         }
 
+        [Fact]
+        public async Task ExecuteAsync_CliTool_FailureAfterDeploy_CleansUpSymlinksAndArtifacts()
+        {
+            using (InitCommandTestBuilder b = new InitCommandTestBuilder())
+            {
+                await b.RegisterCliToolWithPluginAsync(localName: "rg", remoteName: "BurntSushi/ripgrep");
+
+                b.DistributionClient.SetLatestVersion("BurntSushi/ripgrep", new Version(1, 0, 0));
+                b.ServiceDeployer.SetDeployResult("rg", new Version(1, 0, 0), "ripgrep");
+
+                // First symlink (bin) succeeds, second (alias) throws
+                b.SymlinkManager.ThrowAfterCreateCount = 1;
+
+                InitCommand command = b.Build();
+                int exitCode = await command.ExecuteAsync(new[] { "rg" });
+
+                Assert.Equal(1, exitCode);
+                Assert.Contains(b.OutputWriter.Errors, e => e.Contains("Error during initialization"));
+
+                // Should have called cleanup on the deployer
+                Assert.Contains(b.ServiceDeployer.MethodCalls, c => c.StartsWith("CleanupDeployAsync:"));
+                Assert.Single(b.ServiceDeployer.CleanedUpDeploys);
+            }
+        }
+
+        [Fact]
+        public async Task ExecuteAsync_CliTool_FailureOnBinSymlink_CleansUpArtifacts()
+        {
+            using (InitCommandTestBuilder b = new InitCommandTestBuilder())
+            {
+                await b.RegisterCliToolWithPluginAsync(localName: "my-tool", remoteName: "owner/tool");
+
+                b.DistributionClient.SetLatestVersion("owner/tool", new Version(1, 0, 0));
+                b.ServiceDeployer.SetDeployResult("my-tool", new Version(1, 0, 0), "my-tool");
+
+                // Fail on the first symlink creation (the bin symlink)
+                b.SymlinkManager.ThrowAfterCreateCount = 0;
+
+                InitCommand command = b.Build();
+                int exitCode = await command.ExecuteAsync(new[] { "my-tool" });
+
+                Assert.Equal(1, exitCode);
+                Assert.Contains(b.OutputWriter.Errors, e => e.Contains("Error during initialization"));
+
+                // Should have called cleanup on the deployer
+                Assert.Contains(b.ServiceDeployer.MethodCalls, c => c.StartsWith("CleanupDeployAsync:"));
+                Assert.Single(b.ServiceDeployer.CleanedUpDeploys);
+            }
+        }
+
         /// <summary>
         /// A unit file manager that captures the arguments passed to ReadTemplateWithSubstitutionsAsync.
         /// </summary>

--- a/Updaemon.Tests/Commands/NewCommandTests.cs
+++ b/Updaemon.Tests/Commands/NewCommandTests.cs
@@ -7,46 +7,66 @@ namespace Updaemon.Tests.Commands
 {
     public class NewCommandTests
     {
+        private class NewCommandTestBuilder : IDisposable
+        {
+            public MockConfigManager ConfigManager { get; } = new MockConfigManager();
+            public MockOutputWriter OutputWriter { get; } = new MockOutputWriter();
+            public TempFileHelper TempHelper { get; } = new TempFileHelper();
+            public string ServiceDirectory { get; }
+
+            public NewCommandTestBuilder()
+            {
+                ServiceDirectory = TempHelper.TempDirectory;
+            }
+
+            public NewCommand Build()
+            {
+                return new NewCommand(ConfigManager, OutputWriter, ServiceDirectory);
+            }
+
+            /// <summary>
+            /// Installs a plugin so the command passes validation.
+            /// </summary>
+            public async Task InstallPluginAsync(string pluginAlias = "github")
+            {
+                InstalledPluginInfo pluginInfo = new InstalledPluginInfo { Alias = pluginAlias, Path = "/path/to/plugin" };
+                await ConfigManager.AddOrUpdatePluginAsync(pluginInfo);
+            }
+
+            public void Dispose()
+            {
+                TempHelper.Dispose();
+            }
+        }
+
         [Fact]
         public async Task ExecuteAsync_RegistersServiceWithConfigManager()
         {
-            using (TempFileHelper tempHelper = new TempFileHelper())
+            using (NewCommandTestBuilder b = new NewCommandTestBuilder())
             {
-                MockConfigManager configManager = new MockConfigManager();
-                MockOutputWriter outputWriter = new MockOutputWriter();
-                string serviceDirectory = tempHelper.TempDirectory;
+                await b.InstallPluginAsync();
 
-                NewCommand command = new NewCommand(configManager, outputWriter, serviceDirectory);
-
-                InstalledPluginInfo pluginInfo = new InstalledPluginInfo { Alias = "github", Path = "/path/to/plugin" };
-                await configManager.AddOrUpdatePluginAsync(pluginInfo);
-
+                NewCommand command = b.Build();
                 int exitCode = await command.ExecuteAsync(new[] { "my-api", "--from", "github" });
 
                 Assert.Equal(0, exitCode);
-                Assert.Contains(configManager.MethodCalls, call => call.Contains("RegisterServiceAsync:my-api:my-api"));
+                Assert.Contains(b.ConfigManager.MethodCalls, call => call.Contains("RegisterServiceAsync:my-api:my-api"));
             }
         }
 
         [Fact]
         public async Task ExecuteAsync_DoesNotCreateUnitFileOrEnableService()
         {
-            using (TempFileHelper tempHelper = new TempFileHelper())
+            using (NewCommandTestBuilder b = new NewCommandTestBuilder())
             {
-                MockConfigManager configManager = new MockConfigManager();
-                MockOutputWriter outputWriter = new MockOutputWriter();
-                string serviceDirectory = tempHelper.TempDirectory;
+                await b.InstallPluginAsync();
 
-                NewCommand command = new NewCommand(configManager, outputWriter, serviceDirectory);
-
-                InstalledPluginInfo pluginInfo = new InstalledPluginInfo { Alias = "github", Path = "/path/to/plugin" };
-                await configManager.AddOrUpdatePluginAsync(pluginInfo);
-
+                NewCommand command = b.Build();
                 int exitCode = await command.ExecuteAsync(new[] { "my-api", "--from", "github" });
 
                 Assert.Equal(0, exitCode);
                 // No unit file should be created anywhere in the service directory
-                string[] serviceFiles = Directory.GetFiles(Path.Combine(serviceDirectory, "my-api"), "*", SearchOption.AllDirectories);
+                string[] serviceFiles = Directory.GetFiles(Path.Combine(b.ServiceDirectory, "my-api"), "*", SearchOption.AllDirectories);
                 Assert.Empty(serviceFiles);
             }
         }
@@ -54,117 +74,169 @@ namespace Updaemon.Tests.Commands
         [Fact]
         public async Task ExecuteAsync_UsesSameNameForLocalAndRemoteByDefault()
         {
-            using (TempFileHelper tempHelper = new TempFileHelper())
+            using (NewCommandTestBuilder b = new NewCommandTestBuilder())
             {
-                MockConfigManager configManager = new MockConfigManager();
-                MockOutputWriter outputWriter = new MockOutputWriter();
-                string serviceDirectory = tempHelper.TempDirectory;
+                await b.InstallPluginAsync();
 
-                NewCommand command = new NewCommand(configManager, outputWriter, serviceDirectory);
-
-                InstalledPluginInfo pluginInfo = new InstalledPluginInfo { Alias = "github", Path = "/path/to/plugin" };
-                await configManager.AddOrUpdatePluginAsync(pluginInfo);
-
+                NewCommand command = b.Build();
                 int exitCode = await command.ExecuteAsync(new[] { "test-service", "--from", "github" });
 
                 Assert.Equal(0, exitCode);
-                Assert.Contains(configManager.MethodCalls, call => call.Contains("RegisterServiceAsync:test-service:test-service"));
+                Assert.Contains(b.ConfigManager.MethodCalls, call => call.Contains("RegisterServiceAsync:test-service:test-service"));
             }
         }
 
         [Fact]
         public async Task ExecuteAsync_WithRemoteFlag_UsesRemoteNameForRegistration()
         {
-            using (TempFileHelper tempHelper = new TempFileHelper())
+            using (NewCommandTestBuilder b = new NewCommandTestBuilder())
             {
-                MockConfigManager configManager = new MockConfigManager();
-                MockOutputWriter outputWriter = new MockOutputWriter();
-                string serviceDirectory = tempHelper.TempDirectory;
+                await b.InstallPluginAsync();
 
-                NewCommand command = new NewCommand(configManager, outputWriter, serviceDirectory);
-
-                InstalledPluginInfo pluginInfo = new InstalledPluginInfo { Alias = "github", Path = "/path/to/plugin" };
-                await configManager.AddOrUpdatePluginAsync(pluginInfo);
-
+                NewCommand command = b.Build();
                 int exitCode = await command.ExecuteAsync(new[] { "my-api", "--from", "github", "--remote", "owner/repo" });
 
                 Assert.Equal(0, exitCode);
-                Assert.Contains(configManager.MethodCalls, call => call.Contains("RegisterServiceAsync:my-api:owner/repo"));
+                Assert.Contains(b.ConfigManager.MethodCalls, call => call.Contains("RegisterServiceAsync:my-api:owner/repo"));
             }
         }
 
         [Fact]
         public async Task ExecuteAsync_OutputMentionsInitCommand()
         {
-            using (TempFileHelper tempHelper = new TempFileHelper())
+            using (NewCommandTestBuilder b = new NewCommandTestBuilder())
             {
-                MockConfigManager configManager = new MockConfigManager();
-                MockOutputWriter outputWriter = new MockOutputWriter();
-                string serviceDirectory = tempHelper.TempDirectory;
+                await b.InstallPluginAsync();
 
-                NewCommand command = new NewCommand(configManager, outputWriter, serviceDirectory);
-
-                InstalledPluginInfo pluginInfo = new InstalledPluginInfo { Alias = "github", Path = "/path/to/plugin" };
-                await configManager.AddOrUpdatePluginAsync(pluginInfo);
-
+                NewCommand command = b.Build();
                 int exitCode = await command.ExecuteAsync(new[] { "my-api", "--from", "github" });
 
                 Assert.Equal(0, exitCode);
-                Assert.Contains(outputWriter.Messages, m => m.Contains("updaemon init"));
+                Assert.Contains(b.OutputWriter.Messages, m => m.Contains("updaemon init"));
             }
         }
 
         [Fact]
         public async Task ExecuteAsync_PluginNotFound_ReturnsError()
         {
-            using (TempFileHelper tempHelper = new TempFileHelper())
+            using (NewCommandTestBuilder b = new NewCommandTestBuilder())
             {
-                MockConfigManager configManager = new MockConfigManager();
-                MockOutputWriter outputWriter = new MockOutputWriter();
-                string serviceDirectory = tempHelper.TempDirectory;
-
-                NewCommand command = new NewCommand(configManager, outputWriter, serviceDirectory);
-
+                NewCommand command = b.Build();
                 int exitCode = await command.ExecuteAsync(new[] { "my-service", "--from", "non-existent-plugin" });
 
                 Assert.Equal(1, exitCode);
-                Assert.Contains(outputWriter.Errors, e => e.Contains("not installed"));
+                Assert.Contains(b.OutputWriter.Errors, e => e.Contains("not installed"));
             }
         }
 
         [Fact]
         public async Task ExecuteAsync_WithoutAppName_ReturnsErrorCode()
         {
-            using (TempFileHelper tempHelper = new TempFileHelper())
+            using (NewCommandTestBuilder b = new NewCommandTestBuilder())
             {
-                MockConfigManager configManager = new MockConfigManager();
-                MockOutputWriter outputWriter = new MockOutputWriter();
-                string serviceDirectory = tempHelper.TempDirectory;
-
-                NewCommand command = new NewCommand(configManager, outputWriter, serviceDirectory);
-
+                NewCommand command = b.Build();
                 int exitCode = await command.ExecuteAsync(Array.Empty<string>());
 
                 Assert.Equal(1, exitCode);
-                Assert.Contains(outputWriter.Errors, e => e.Contains("Missing required argument"));
+                Assert.Contains(b.OutputWriter.Errors, e => e.Contains("Missing required argument"));
             }
         }
 
         [Fact]
         public async Task ExecuteAsync_WithoutFromFlag_ReturnsErrorCode()
         {
-            using (TempFileHelper tempHelper = new TempFileHelper())
+            using (NewCommandTestBuilder b = new NewCommandTestBuilder())
             {
-                MockConfigManager configManager = new MockConfigManager();
-                MockOutputWriter outputWriter = new MockOutputWriter();
-                string serviceDirectory = tempHelper.TempDirectory;
-
-                NewCommand command = new NewCommand(configManager, outputWriter, serviceDirectory);
-
+                NewCommand command = b.Build();
                 int exitCode = await command.ExecuteAsync(new[] { "my-service" });
 
                 Assert.Equal(1, exitCode);
-                Assert.Contains(outputWriter.Errors, e => e.Contains("Missing required flag"));
+                Assert.Contains(b.OutputWriter.Errors, e => e.Contains("Missing required flag"));
+            }
+        }
+
+        [Fact]
+        public async Task ExecuteAsync_WithTypeCli_RegistersWithCliType()
+        {
+            using (NewCommandTestBuilder b = new NewCommandTestBuilder())
+            {
+                await b.InstallPluginAsync();
+
+                NewCommand command = b.Build();
+                int exitCode = await command.ExecuteAsync(new[] { "my-tool", "--from", "github", "--type", "cli" });
+
+                Assert.Equal(0, exitCode);
+                Assert.Contains(b.ConfigManager.MethodCalls, call => call.Contains("RegisterServiceAsync:my-tool:my-tool:github:Cli"));
+
+                RegisteredService? service = await b.ConfigManager.GetServiceAsync("my-tool");
+                Assert.NotNull(service);
+                Assert.Equal(ServiceType.Cli, service.ServiceType);
+            }
+        }
+
+        [Fact]
+        public async Task ExecuteAsync_WithTypeService_RegistersWithServiceType()
+        {
+            using (NewCommandTestBuilder b = new NewCommandTestBuilder())
+            {
+                await b.InstallPluginAsync();
+
+                NewCommand command = b.Build();
+                int exitCode = await command.ExecuteAsync(new[] { "my-api", "--from", "github", "--type", "service" });
+
+                Assert.Equal(0, exitCode);
+
+                RegisteredService? service = await b.ConfigManager.GetServiceAsync("my-api");
+                Assert.NotNull(service);
+                Assert.Equal(ServiceType.Service, service.ServiceType);
+            }
+        }
+
+        [Fact]
+        public async Task ExecuteAsync_WithoutTypeFlag_DefaultsToService()
+        {
+            using (NewCommandTestBuilder b = new NewCommandTestBuilder())
+            {
+                await b.InstallPluginAsync();
+
+                NewCommand command = b.Build();
+                int exitCode = await command.ExecuteAsync(new[] { "my-api", "--from", "github" });
+
+                Assert.Equal(0, exitCode);
+
+                RegisteredService? service = await b.ConfigManager.GetServiceAsync("my-api");
+                Assert.NotNull(service);
+                Assert.Equal(ServiceType.Service, service.ServiceType);
+            }
+        }
+
+        [Fact]
+        public async Task ExecuteAsync_WithInvalidType_ReturnsError()
+        {
+            using (NewCommandTestBuilder b = new NewCommandTestBuilder())
+            {
+                await b.InstallPluginAsync();
+
+                NewCommand command = b.Build();
+                int exitCode = await command.ExecuteAsync(new[] { "my-tool", "--from", "github", "--type", "daemon" });
+
+                Assert.Equal(1, exitCode);
+                Assert.Contains(b.OutputWriter.Errors, e => e.Contains("Invalid type"));
+            }
+        }
+
+        [Fact]
+        public async Task ExecuteAsync_WithTypeCli_OutputSaysCliTool()
+        {
+            using (NewCommandTestBuilder b = new NewCommandTestBuilder())
+            {
+                await b.InstallPluginAsync();
+
+                NewCommand command = b.Build();
+                int exitCode = await command.ExecuteAsync(new[] { "my-tool", "--from", "github", "--type", "cli" });
+
+                Assert.Equal(0, exitCode);
+                Assert.Contains(b.OutputWriter.Messages, m => m.Contains("CLI tool"));
             }
         }
     }

--- a/Updaemon.Tests/Commands/UpdateCommandTests.cs
+++ b/Updaemon.Tests/Commands/UpdateCommandTests.cs
@@ -603,6 +603,47 @@ namespace Updaemon.Tests.Commands
         }
 
         [Fact]
+        public async Task ExecuteAsync_UninitializedCliTool_SkipsWithWarning()
+        {
+            using (TempFileHelper tempHelper = new TempFileHelper())
+            {
+                MockConfigManager configManager = new MockConfigManager();
+                string pluginPath = tempHelper.CreateTempFile("plugins/github/bin", "fake-plugin");
+                await configManager.AddOrUpdatePluginAsync(new InstalledPluginInfo { Alias = "github", Path = pluginPath });
+                await configManager.RegisterServiceAsync("my-tool", "MyTool", "github", ServiceType.Cli);
+
+                MockOutputWriter outputWriter = new MockOutputWriter();
+                MockServiceDeployer serviceDeployer = new MockServiceDeployer();
+                // No initialized target — CLI tool is not initialized
+
+                MockDistributionServiceClient distributionClient = new MockDistributionServiceClient();
+                distributionClient.SetLatestVersion("MyTool", new Version(1, 0, 0));
+
+                MockServiceManager serviceManager = new MockServiceManager();
+
+                UpdateCommand command = new UpdateCommand(
+                    configManager,
+                    new MockSecretsManager(),
+                    serviceManager,
+                    distributionClient,
+                    outputWriter,
+                    new MockVersionExtractor(),
+                    serviceDeployer
+                );
+
+                int exitCode = await command.ExecuteAsync(new[] { "my-tool" });
+                Assert.Equal(0, exitCode);
+
+                Assert.Contains(outputWriter.Messages, m => m.Contains("not initialized") && m.Contains("updaemon init"));
+                Assert.DoesNotContain(serviceDeployer.MethodCalls, c => c.StartsWith("DeployVersionAsync"));
+
+                // Should NOT have called any service manager methods
+                Assert.Empty(serviceManager.MethodCalls.Where(call =>
+                    call.Contains("Start") || call.Contains("Restart") || call.Contains("ServiceExists") || call.Contains("IsServiceRunning")));
+            }
+        }
+
+        [Fact]
         public async Task ExecuteAsync_PluginExecutableNotFound_SkipsWithError()
         {
             MockConfigManager configManager = new MockConfigManager();

--- a/Updaemon.Tests/Commands/UpdateCommandTests.cs
+++ b/Updaemon.Tests/Commands/UpdateCommandTests.cs
@@ -554,6 +554,55 @@ namespace Updaemon.Tests.Commands
         }
 
         [Fact]
+        public async Task UpdateService_CliType_DoesNotRestartService()
+        {
+            using (TempFileHelper tempHelper = new TempFileHelper())
+            {
+                MockConfigManager configManager = new MockConfigManager();
+                string pluginPath = tempHelper.CreateTempFile("plugins/github/bin", "fake-plugin");
+                InstalledPluginInfo pluginInfo = new InstalledPluginInfo { Alias = "github", Path = pluginPath };
+                await configManager.AddOrUpdatePluginAsync(pluginInfo);
+                await configManager.RegisterServiceAsync("my-tool", "MyTool", "github", ServiceType.Cli);
+
+                MockServiceDeployer serviceDeployer = new MockServiceDeployer();
+                serviceDeployer.SetInitialized("my-tool", "/opt/my-tool/1.0.0");
+                serviceDeployer.SetDeployResult("my-tool", new Version(1, 1, 0));
+
+                MockDistributionServiceClient distributionClient = new MockDistributionServiceClient();
+                distributionClient.SetLatestVersion("MyTool", new Version(1, 1, 0));
+
+                MockVersionExtractor versionExtractor = new MockVersionExtractor();
+                versionExtractor.ExtractVersionFromPathResult = new Version(1, 0, 0);
+
+                MockServiceManager serviceManager = new MockServiceManager();
+                MockOutputWriter outputWriter = new MockOutputWriter();
+
+                UpdateCommand command = new UpdateCommand(
+                    configManager,
+                    new MockSecretsManager(),
+                    serviceManager,
+                    distributionClient,
+                    outputWriter,
+                    versionExtractor,
+                    serviceDeployer
+                );
+
+                int exitCode = await command.ExecuteAsync(new[] { "my-tool" });
+                Assert.Equal(0, exitCode);
+
+                // Should have deployed the new version
+                Assert.Contains(serviceDeployer.MethodCalls, call => call == "DeployVersionAsync:my-tool:1.1.0");
+
+                // Should NOT have called any service manager methods
+                Assert.Empty(serviceManager.MethodCalls.Where(call =>
+                    call.Contains("Start") || call.Contains("Restart") || call.Contains("ServiceExists") || call.Contains("IsServiceRunning")));
+
+                // Should print CLI success message
+                Assert.Contains(outputWriter.Messages, m => m.Contains("CLI tool updated successfully"));
+            }
+        }
+
+        [Fact]
         public async Task ExecuteAsync_PluginExecutableNotFound_SkipsWithError()
         {
             MockConfigManager configManager = new MockConfigManager();

--- a/Updaemon.Tests/Configuration/ConfigManagerTests.cs
+++ b/Updaemon.Tests/Configuration/ConfigManagerTests.cs
@@ -326,6 +326,49 @@ namespace Updaemon.Tests.Configuration
                 Assert.Null(config.Services[0].ExecutableName);
             }
         }
+
+        [Fact]
+        public async Task LoadConfigAsync_OldConfigWithoutServiceType_DefaultsToService()
+        {
+            using (TempFileHelper tempHelper = new TempFileHelper())
+            {
+                string configPath = Path.Combine(tempHelper.TempDirectory, "config.json");
+                string oldConfigJson = @"{
+  ""installedPlugins"": {},
+  ""services"": [
+    {
+      ""localName"": ""test-service"",
+      ""remoteName"": ""TestService"",
+      ""distributionPluginAlias"": ""github""
+    }
+  ]
+}";
+                Directory.CreateDirectory(tempHelper.TempDirectory);
+                await File.WriteAllTextAsync(configPath, oldConfigJson);
+
+                ConfigManager configManager = new ConfigManager(tempHelper.TempDirectory);
+                UpdaemonConfig config = await configManager.LoadConfigAsync();
+
+                Assert.NotNull(config);
+                Assert.Single(config.Services);
+                Assert.Equal(ServiceType.Service, config.Services[0].ServiceType);
+            }
+        }
+
+        [Fact]
+        public async Task RegisterServiceAsync_WithCliType_PersistsType()
+        {
+            using (TempFileHelper tempHelper = new TempFileHelper())
+            {
+                ConfigManager configManager = new ConfigManager(tempHelper.TempDirectory);
+
+                await configManager.RegisterServiceAsync("my-tool", "owner/tool", "github", ServiceType.Cli);
+
+                UpdaemonConfig config = await configManager.LoadConfigAsync();
+                Assert.Single(config.Services);
+                Assert.Equal(ServiceType.Cli, config.Services[0].ServiceType);
+            }
+        }
     }
 }
 

--- a/Updaemon.Tests/Mocks/MockConfigManager.cs
+++ b/Updaemon.Tests/Mocks/MockConfigManager.cs
@@ -24,9 +24,9 @@ namespace Updaemon.Tests.Mocks
             return Task.CompletedTask;
         }
 
-        public async Task RegisterServiceAsync(string localName, string remoteName, string distributionPluginAlias, CancellationToken cancellationToken = default)
+        public async Task RegisterServiceAsync(string localName, string remoteName, string distributionPluginAlias, ServiceType serviceType = ServiceType.Service, CancellationToken cancellationToken = default)
         {
-            MethodCalls.Add($"{nameof(RegisterServiceAsync)}:{localName}:{remoteName}:{distributionPluginAlias}");
+            MethodCalls.Add($"{nameof(RegisterServiceAsync)}:{localName}:{remoteName}:{distributionPluginAlias}:{serviceType}");
             UpdaemonConfig config = await LoadConfigAsync(cancellationToken);
 
             RegisteredService? existing = config.Services.FirstOrDefault(s => s.LocalName == localName);
@@ -40,6 +40,7 @@ namespace Updaemon.Tests.Mocks
                 LocalName = localName,
                 RemoteName = remoteName,
                 DistributionPluginAlias = distributionPluginAlias,
+                ServiceType = serviceType,
             });
 
             await SaveConfigAsync(config, cancellationToken);

--- a/Updaemon.Tests/Mocks/MockSymlinkManager.cs
+++ b/Updaemon.Tests/Mocks/MockSymlinkManager.cs
@@ -10,9 +10,22 @@ namespace Updaemon.Tests.Mocks
         public List<string> MethodCalls { get; } = new List<string>();
         public Dictionary<string, string> Symlinks { get; } = new Dictionary<string, string>();
 
+        /// <summary>
+        /// When set, CreateOrUpdateSymlinkAsync will throw after this many successful calls.
+        /// </summary>
+        public int? ThrowAfterCreateCount { get; set; }
+        private int _createCount;
+
         public Task CreateOrUpdateSymlinkAsync(string linkPath, string targetPath, CancellationToken cancellationToken = default)
         {
             MethodCalls.Add($"{nameof(CreateOrUpdateSymlinkAsync)}:{linkPath}:{targetPath}");
+
+            if (ThrowAfterCreateCount.HasValue && _createCount >= ThrowAfterCreateCount.Value)
+            {
+                throw new IOException("Simulated symlink creation failure");
+            }
+
+            _createCount++;
             Symlinks[linkPath] = targetPath;
             return Task.CompletedTask;
         }

--- a/Updaemon/Commands/InitCommand.cs
+++ b/Updaemon/Commands/InitCommand.cs
@@ -4,7 +4,7 @@ using Updaemon.Models;
 namespace Updaemon.Commands
 {
     /// <summary>
-    /// Handles the 'init' command to perform first-time download and setup of a registered service.
+    /// Handles the 'init' command to perform first-time download and setup of a registered service or CLI tool.
     /// </summary>
     public class InitCommand : ICommand
     {
@@ -15,7 +15,9 @@ namespace Updaemon.Commands
         private readonly IOutputWriter _outputWriter;
         private readonly IUnitFileManager _unitFileManager;
         private readonly IServiceDeployer _serviceDeployer;
+        private readonly ISymlinkManager _symlinkManager;
         private readonly string _systemdUnitDirectory;
+        private readonly string _binDirectory;
 
         public InitCommand(
             IConfigManager configManager,
@@ -24,7 +26,8 @@ namespace Updaemon.Commands
             IDistributionServiceClient distributionClient,
             IOutputWriter outputWriter,
             IUnitFileManager unitFileManager,
-            IServiceDeployer serviceDeployer)
+            IServiceDeployer serviceDeployer,
+            ISymlinkManager symlinkManager)
         {
             _configManager = configManager;
             _secretsManager = secretsManager;
@@ -33,7 +36,9 @@ namespace Updaemon.Commands
             _outputWriter = outputWriter;
             _unitFileManager = unitFileManager;
             _serviceDeployer = serviceDeployer;
+            _symlinkManager = symlinkManager;
             _systemdUnitDirectory = "/etc/systemd/system";
+            _binDirectory = "/usr/local/bin";
         }
 
         public InitCommand(
@@ -44,7 +49,9 @@ namespace Updaemon.Commands
             IOutputWriter outputWriter,
             IUnitFileManager unitFileManager,
             IServiceDeployer serviceDeployer,
-            string systemdUnitDirectory)
+            ISymlinkManager symlinkManager,
+            string systemdUnitDirectory,
+            string binDirectory)
         {
             _configManager = configManager;
             _secretsManager = secretsManager;
@@ -53,12 +60,14 @@ namespace Updaemon.Commands
             _outputWriter = outputWriter;
             _unitFileManager = unitFileManager;
             _serviceDeployer = serviceDeployer;
+            _symlinkManager = symlinkManager;
             _systemdUnitDirectory = systemdUnitDirectory;
+            _binDirectory = binDirectory;
         }
 
         public string Name => "init";
 
-        public string Description => "Download and set up a registered service for the first time";
+        public string Description => "Download and set up a registered service or CLI tool for the first time";
 
         public string Usage => "updaemon init <app-name>";
 
@@ -76,7 +85,7 @@ namespace Updaemon.Commands
             RegisteredService? service = await _configManager.GetServiceAsync(appName, cancellationToken);
             if (service == null)
             {
-                _outputWriter.WriteError($"Error: Service '{appName}' is not registered. Use 'updaemon new' to register it first.");
+                _outputWriter.WriteError($"Error: '{appName}' is not registered. Use 'updaemon new' to register it first.");
                 return 1;
             }
 
@@ -84,7 +93,7 @@ namespace Updaemon.Commands
             string? existingTarget = await _serviceDeployer.ReadCurrentTargetAsync(service.LocalName, cancellationToken);
             if (existingTarget != null)
             {
-                _outputWriter.WriteLine($"Service '{appName}' is already initialized.");
+                _outputWriter.WriteLine($"{service.ServiceType.ToLabel()} '{appName}' is already initialized.");
                 return 0;
             }
 
@@ -102,29 +111,19 @@ namespace Updaemon.Commands
                 return 1;
             }
 
-            // Pre-flight: check write access to systemd unit directory
-            if (!Directory.Exists(_systemdUnitDirectory))
+            // Pre-flight: check write access
+            if (service.ServiceType == ServiceType.Cli)
             {
-                _outputWriter.WriteError($"Error: Systemd unit directory '{_systemdUnitDirectory}' does not exist.");
-                return 1;
+                int preflightResult = await CheckWriteAccessAsync(_binDirectory, cancellationToken);
+                if (preflightResult != 0) return preflightResult;
+            }
+            else
+            {
+                int preflightResult = await CheckWriteAccessAsync(_systemdUnitDirectory, cancellationToken);
+                if (preflightResult != 0) return preflightResult;
             }
 
-            string testFilePath = Path.Combine(_systemdUnitDirectory, $".updaemon-init-check-{Guid.NewGuid()}");
-            try
-            {
-                await File.WriteAllTextAsync(testFilePath, "", cancellationToken);
-            }
-            catch (UnauthorizedAccessException)
-            {
-                _outputWriter.WriteError($"Error: No write access to '{_systemdUnitDirectory}'. Run with appropriate permissions.");
-                return 1;
-            }
-            finally
-            {
-                try { File.Delete(testFilePath); } catch { }
-            }
-
-            _outputWriter.WriteLine($"Initializing service: {appName}");
+            _outputWriter.WriteLine($"Initializing {service.ServiceType.ToLabel()}: {appName}");
 
             // Connect to plugin
             await _distributionClient.ConnectAsync(pluginInfo.Path, cancellationToken);
@@ -133,6 +132,8 @@ namespace Updaemon.Commands
 
             DeployResult? deployResult = null;
             string? unitFilePath = null;
+            string? binSymlinkPath = null;
+            string? binAliasSymlinkPath = null;
 
             try
             {
@@ -153,19 +154,41 @@ namespace Updaemon.Commands
                     return 1;
                 }
 
-                // Generate and write unit file
                 string detectedExecutableName = Path.GetFileName(deployResult.ExecutablePath);
-                unitFilePath = Path.Combine(_systemdUnitDirectory, $"{service.LocalName}.service");
 
-                await _unitFileManager.WriteUnitFileAsync(
-                    unitFilePath, service.LocalName, deployResult.SymlinkPath, detectedExecutableName, cancellationToken);
-                _outputWriter.WriteLine($"Created systemd unit file: {unitFilePath}");
+                if (service.ServiceType == ServiceType.Cli)
+                {
+                    // Create symlink in bin directory using the executable's real name
+                    binSymlinkPath = Path.Combine(_binDirectory, detectedExecutableName);
+                    string targetPath = Path.Combine(deployResult.SymlinkPath, detectedExecutableName);
+                    await _symlinkManager.CreateOrUpdateSymlinkAsync(binSymlinkPath, targetPath, cancellationToken);
+                    _outputWriter.WriteLine($"Created symlink: {binSymlinkPath}");
 
-                // Reload systemd and enable/start service
-                await _serviceManager.DaemonReloadAsync(cancellationToken);
-                await _serviceManager.EnableServiceAsync(service.LocalName, cancellationToken);
-                await _serviceManager.StartServiceAsync(service.LocalName, cancellationToken);
-                _outputWriter.WriteLine($"Service '{appName}' initialized and started successfully!");
+                    // Create an alias symlink using the user-chosen local name, if different
+                    if (!string.Equals(service.LocalName, detectedExecutableName, StringComparison.Ordinal))
+                    {
+                        binAliasSymlinkPath = Path.Combine(_binDirectory, service.LocalName);
+                        await _symlinkManager.CreateOrUpdateSymlinkAsync(binAliasSymlinkPath, targetPath, cancellationToken);
+                        _outputWriter.WriteLine($"Created alias symlink: {binAliasSymlinkPath}");
+                    }
+
+                    _outputWriter.WriteLine($"CLI tool '{appName}' initialized successfully!");
+                }
+                else
+                {
+                    // Generate and write unit file
+                    unitFilePath = Path.Combine(_systemdUnitDirectory, $"{service.LocalName}.service");
+
+                    await _unitFileManager.WriteUnitFileAsync(
+                        unitFilePath, service.LocalName, deployResult.SymlinkPath, detectedExecutableName, cancellationToken);
+                    _outputWriter.WriteLine($"Created systemd unit file: {unitFilePath}");
+
+                    // Reload systemd and enable/start service
+                    await _serviceManager.DaemonReloadAsync(cancellationToken);
+                    await _serviceManager.EnableServiceAsync(service.LocalName, cancellationToken);
+                    await _serviceManager.StartServiceAsync(service.LocalName, cancellationToken);
+                    _outputWriter.WriteLine($"Service '{appName}' initialized and started successfully!");
+                }
 
                 return 0;
             }
@@ -177,6 +200,16 @@ namespace Updaemon.Commands
                 if (unitFilePath != null)
                 {
                     try { File.Delete(unitFilePath); } catch { }
+                }
+
+                // Clean up bin symlinks
+                if (binSymlinkPath != null)
+                {
+                    try { File.Delete(binSymlinkPath); } catch { }
+                }
+                if (binAliasSymlinkPath != null)
+                {
+                    try { File.Delete(binAliasSymlinkPath); } catch { }
                 }
 
                 // Clean up deploy artifacts (version directory + symlink)
@@ -194,6 +227,32 @@ namespace Updaemon.Commands
             }
         }
 
+        private async Task<int> CheckWriteAccessAsync(string directory, CancellationToken cancellationToken)
+        {
+            if (!Directory.Exists(directory))
+            {
+                _outputWriter.WriteError($"Error: Directory '{directory}' does not exist.");
+                return 1;
+            }
+
+            string testFilePath = Path.Combine(directory, $".updaemon-init-check-{Guid.NewGuid()}");
+            try
+            {
+                await File.WriteAllTextAsync(testFilePath, "", cancellationToken);
+            }
+            catch (UnauthorizedAccessException)
+            {
+                _outputWriter.WriteError($"Error: No write access to '{directory}'. Run with appropriate permissions.");
+                return 1;
+            }
+            finally
+            {
+                try { File.Delete(testFilePath); } catch { }
+            }
+
+            return 0;
+        }
+
         public string GetDetailedHelp()
         {
             return """
@@ -203,16 +262,20 @@ namespace Updaemon.Commands
                   updaemon init <app-name>
 
                 Description:
-                  Downloads and sets up a registered service for the first time. This command
-                  downloads the latest version, detects the executable, creates the systemd
-                  unit file with the correct ExecStart path, and starts the service.
+                  Downloads and sets up a registered service or CLI tool for the first time.
 
-                  The service must first be registered with 'updaemon new'. If the service
-                  is already initialized, this command does nothing.
+                  For services: downloads the latest version, detects the executable, creates
+                  the systemd unit file, and starts the service.
+
+                  For CLI tools: downloads the latest version, detects the executable, and
+                  creates a symlink in /usr/local/bin so the tool is available on PATH.
+
+                  The entry must first be registered with 'updaemon new'. If it is already
+                  initialized, this command does nothing.
 
                 Examples:
                   updaemon init my-api
-                  updaemon init my-service
+                  updaemon init ripgrep
                 """;
         }
     }

--- a/Updaemon/Commands/NewCommand.cs
+++ b/Updaemon/Commands/NewCommand.cs
@@ -33,9 +33,9 @@ namespace Updaemon.Commands
 
         public string Name => "new";
 
-        public string Description => "Register a new service";
+        public string Description => "Register a new service or CLI tool";
 
-        public string Usage => "updaemon new <app-name> --from <plugin-alias> [--remote <remote-name>]";
+        public string Usage => "updaemon new <app-name> --from <plugin-alias> [--remote <remote-name>] [--type <service|cli>]";
 
         public async Task<int> ExecuteAsync(string[] args, CancellationToken cancellationToken = default)
         {
@@ -55,6 +55,21 @@ namespace Updaemon.Commands
 
             string? remoteName = parser.GetFlag("--remote");
 
+            string? typeFlag = parser.GetFlag("--type");
+            ServiceType serviceType = ServiceType.Service;
+            if (typeFlag != null)
+            {
+                if (string.Equals(typeFlag, "cli", StringComparison.OrdinalIgnoreCase))
+                {
+                    serviceType = ServiceType.Cli;
+                }
+                else if (!string.Equals(typeFlag, "service", StringComparison.OrdinalIgnoreCase))
+                {
+                    _outputWriter.WriteError($"Error: Invalid type '{typeFlag}'. Must be 'service' or 'cli'.");
+                    return 1;
+                }
+            }
+
             // Verify plugin exists
             InstalledPluginInfo? pluginInfo = await _configManager.GetPluginAsync(distributionPluginAlias, cancellationToken);
             if (pluginInfo == null)
@@ -63,7 +78,8 @@ namespace Updaemon.Commands
                 return 1;
             }
 
-            _outputWriter.WriteLine($"Registering new service: {appName}");
+            string typeLabel = serviceType.ToLabel();
+            _outputWriter.WriteLine($"Registering new {typeLabel}: {appName}");
 
             // Create the service directory
             string serviceDirectory = Path.Combine(_serviceBaseDirectory, appName);
@@ -72,17 +88,17 @@ namespace Updaemon.Commands
 
             // Register the service
             string effectiveRemoteName = remoteName ?? appName;
-            await _configManager.RegisterServiceAsync(appName, effectiveRemoteName, distributionPluginAlias, cancellationToken);
-            _outputWriter.WriteLine($"Registered service in updaemon config");
+            await _configManager.RegisterServiceAsync(appName, effectiveRemoteName, distributionPluginAlias, serviceType, cancellationToken);
+            _outputWriter.WriteLine($"Registered {typeLabel} in updaemon config");
 
-            _outputWriter.WriteLine($"Service '{appName}' registered successfully!");
+            _outputWriter.WriteLine($"{typeLabel} '{appName}' registered successfully!");
 
             if (remoteName == null)
             {
                 _outputWriter.WriteLine($"Note: Remote name defaults to '{appName}'. Use 'updaemon set-remote {appName} <remote-name>' to change it.");
             }
 
-            _outputWriter.WriteLine($"Run 'updaemon init {appName}' to download and set up the service.");
+            _outputWriter.WriteLine($"Run 'updaemon init {appName}' to download and set up the {typeLabel}.");
             return 0;
         }
 
@@ -92,20 +108,23 @@ namespace Updaemon.Commands
                 New Command
 
                 Usage:
-                  updaemon new <app-name> --from <plugin-alias> [--remote <remote-name>]
+                  updaemon new <app-name> --from <plugin-alias> [--remote <remote-name>] [--type <service|cli>]
 
                 Description:
-                  Registers a new service with the specified name. The service will use the
-                  specified distribution plugin to check for updates. After registering,
-                  run 'updaemon init <app-name>' to download and set up the service.
+                  Registers a new service or CLI tool with the specified name. The entry will
+                  use the specified distribution plugin to check for updates. After registering,
+                  run 'updaemon init <app-name>' to download and set it up.
 
                 Options:
-                  --remote <remote-name>  Set the remote name (defaults to app-name)
+                  --remote <remote-name>       Set the remote name (defaults to app-name)
+                  --type <service|cli>         Set the type (defaults to service)
+                                               service: managed as a systemd service
+                                               cli: symlinked into /usr/local/bin
 
                 Examples:
                   updaemon new my-api --from github
                   updaemon new my-api --from github --remote owner/repo
-                  updaemon new my-service --from byteshelf
+                  updaemon new ripgrep --from github --remote BurntSushi/ripgrep --type cli
                 """;
         }
     }

--- a/Updaemon/Commands/UpdateCommand.cs
+++ b/Updaemon/Commands/UpdateCommand.cs
@@ -51,7 +51,7 @@ namespace Updaemon.Commands
                 RegisteredService? service = await _configManager.GetServiceAsync(specificAppName, cancellationToken);
                 if (service == null)
                 {
-                    _outputWriter.WriteError($"Error: Service '{specificAppName}' is not registered.");
+                    _outputWriter.WriteError($"Error: '{specificAppName}' is not registered.");
                     return 1;
                 }
 
@@ -64,7 +64,7 @@ namespace Updaemon.Commands
 
             if (services.Count == 0)
             {
-                _outputWriter.WriteLine("No services registered. Use 'updaemon new <app-name> --from <plugin>' to create a service.");
+                _outputWriter.WriteLine("Nothing registered. Use 'updaemon new <app-name> --from <plugin>' to register a service or CLI tool.");
                 return 0;
             }
 
@@ -74,7 +74,7 @@ namespace Updaemon.Commands
             {
                 if (string.IsNullOrEmpty(service.DistributionPluginAlias))
                 {
-                    _outputWriter.WriteError($"Error: Service '{service.LocalName}' does not have a distribution plugin assigned.");
+                    _outputWriter.WriteError($"Error: '{service.LocalName}' does not have a distribution plugin assigned.");
                     continue;
                 }
 
@@ -120,7 +120,7 @@ namespace Updaemon.Commands
                 return;
             }
 
-            _outputWriter.WriteLine($"\n=== Updating services using plugin '{pluginAlias}' ===");
+            _outputWriter.WriteLine($"\n=== Updating entries using plugin '{pluginAlias}' ===");
 
             // Connect to the distribution service
             await _distributionClient.ConnectAsync(pluginInfo.Path, cancellationToken);
@@ -141,7 +141,7 @@ namespace Updaemon.Commands
 
         private async Task UpdateServiceAsync(RegisteredService service, CancellationToken cancellationToken)
         {
-            _outputWriter.WriteLine($"\nUpdating service: {service.LocalName}");
+            _outputWriter.WriteLine($"\nUpdating {service.ServiceType.ToLabel()}: {service.LocalName}");
 
             try
             {

--- a/Updaemon/Commands/UpdateCommand.cs
+++ b/Updaemon/Commands/UpdateCommand.cs
@@ -36,7 +36,7 @@ namespace Updaemon.Commands
 
         public string Name => "update";
 
-        public string Description => "Update all services or a specific service";
+        public string Description => "Update all services and CLI tools, or a specific one";
 
         public string Usage => "updaemon update [app-name]";
 
@@ -188,32 +188,39 @@ namespace Updaemon.Commands
                     return;
                 }
 
-                // Restart service
-                bool serviceExists = await _serviceManager.ServiceExistsAsync(service.LocalName, cancellationToken);
-                if (serviceExists)
+                if (service.ServiceType == ServiceType.Cli)
                 {
-                    bool isRunning = await _serviceManager.IsServiceRunningAsync(service.LocalName, cancellationToken);
-                    if (isRunning)
-                    {
-                        _outputWriter.WriteLine("Restarting service...");
-                        await _serviceManager.RestartServiceAsync(service.LocalName, cancellationToken);
-                    }
-                    else
-                    {
-                        _outputWriter.WriteLine("Starting service...");
-                        await _serviceManager.StartServiceAsync(service.LocalName, cancellationToken);
-                    }
-
-                    _outputWriter.WriteLine("Service updated successfully");
+                    _outputWriter.WriteLine("CLI tool updated successfully");
                 }
                 else
                 {
-                    _outputWriter.WriteLine("Warning: systemd unit file not found. Service not started.");
+                    // Restart service
+                    bool serviceExists = await _serviceManager.ServiceExistsAsync(service.LocalName, cancellationToken);
+                    if (serviceExists)
+                    {
+                        bool isRunning = await _serviceManager.IsServiceRunningAsync(service.LocalName, cancellationToken);
+                        if (isRunning)
+                        {
+                            _outputWriter.WriteLine("Restarting service...");
+                            await _serviceManager.RestartServiceAsync(service.LocalName, cancellationToken);
+                        }
+                        else
+                        {
+                            _outputWriter.WriteLine("Starting service...");
+                            await _serviceManager.StartServiceAsync(service.LocalName, cancellationToken);
+                        }
+
+                        _outputWriter.WriteLine("Service updated successfully");
+                    }
+                    else
+                    {
+                        _outputWriter.WriteLine("Warning: systemd unit file not found. Service not started.");
+                    }
                 }
             }
             catch (Exception ex)
             {
-                _outputWriter.WriteError($"Error updating service: {ex.Message}");
+                _outputWriter.WriteError($"Error updating {service.ServiceType.ToLabel()}: {ex.Message}");
             }
         }
 
@@ -226,13 +233,16 @@ namespace Updaemon.Commands
                   updaemon update [app-name]
 
                 Description:
-                  Updates all registered services to their latest versions. If an app-name
-                  is provided, only that specific service is updated. Services are grouped
-                  by distribution plugin and updated efficiently.
+                  Updates all registered services and CLI tools to their latest versions.
+                  If an app-name is provided, only that specific entry is updated. Entries
+                  are grouped by distribution plugin and updated efficiently.
+
+                  For services, the systemd service is restarted after updating.
+                  For CLI tools, the symlink chain resolves automatically to the new version.
 
                 Examples:
-                  updaemon update          # Update all services
-                  updaemon update my-api  # Update only my-api
+                  updaemon update          # Update all
+                  updaemon update my-api   # Update only my-api
                 """;
         }
     }

--- a/Updaemon/Configuration/ConfigManager.cs
+++ b/Updaemon/Configuration/ConfigManager.cs
@@ -47,7 +47,7 @@ namespace Updaemon.Configuration
             await File.WriteAllTextAsync(_configFilePath, json, cancellationToken);
         }
 
-        public async Task RegisterServiceAsync(string localName, string remoteName, string distributionPluginAlias, CancellationToken cancellationToken = default)
+        public async Task RegisterServiceAsync(string localName, string remoteName, string distributionPluginAlias, ServiceType serviceType = ServiceType.Service, CancellationToken cancellationToken = default)
         {
             UpdaemonConfig config = await LoadConfigAsync(cancellationToken);
 
@@ -62,6 +62,7 @@ namespace Updaemon.Configuration
                 LocalName = localName,
                 RemoteName = remoteName,
                 DistributionPluginAlias = distributionPluginAlias,
+                ServiceType = serviceType,
             });
 
             await SaveConfigAsync(config, cancellationToken);

--- a/Updaemon/Interfaces/IConfigManager.cs
+++ b/Updaemon/Interfaces/IConfigManager.cs
@@ -20,7 +20,7 @@ namespace Updaemon.Interfaces
         /// <summary>
         /// Registers a new service.
         /// </summary>
-        Task RegisterServiceAsync(string localName, string remoteName, string distributionPluginAlias, CancellationToken cancellationToken = default);
+        Task RegisterServiceAsync(string localName, string remoteName, string distributionPluginAlias, ServiceType serviceType = ServiceType.Service, CancellationToken cancellationToken = default);
 
         /// <summary>
         /// Updates the remote name for an existing service.

--- a/Updaemon/Models/RegisteredService.cs
+++ b/Updaemon/Models/RegisteredService.cs
@@ -6,7 +6,7 @@ namespace Updaemon.Models
     public class RegisteredService
     {
         /// <summary>
-        /// Local name used for systemd service and directory at /opt/{LocalName}/
+        /// Local name used for the directory at /opt/{LocalName}/ and (for services) the systemd unit name.
         /// </summary>
         public string LocalName { get; set; } = string.Empty;
 

--- a/Updaemon/Models/RegisteredService.cs
+++ b/Updaemon/Models/RegisteredService.cs
@@ -25,6 +25,12 @@ namespace Updaemon.Models
         /// Alias of the distribution plugin to use for this service.
         /// </summary>
         public string DistributionPluginAlias { get; set; } = string.Empty;
+
+        /// <summary>
+        /// The type of this entry: Service (systemd managed) or Cli (PATH symlink only).
+        /// Defaults to Service for backwards compatibility with existing configs.
+        /// </summary>
+        public ServiceType ServiceType { get; set; } = ServiceType.Service;
     }
 }
 

--- a/Updaemon/Models/ServiceType.cs
+++ b/Updaemon/Models/ServiceType.cs
@@ -1,0 +1,22 @@
+using System.Text.Json.Serialization;
+
+namespace Updaemon.Models
+{
+    [JsonConverter(typeof(JsonStringEnumConverter<ServiceType>))]
+    public enum ServiceType
+    {
+        Service = 0,
+        Cli = 1,
+    }
+
+    public static class ServiceTypeExtensions
+    {
+        /// <summary>
+        /// Returns a human-readable label for the service type (e.g. "service" or "CLI tool").
+        /// </summary>
+        public static string ToLabel(this ServiceType serviceType)
+        {
+            return serviceType == ServiceType.Cli ? "CLI tool" : "service";
+        }
+    }
+}

--- a/Updaemon/Serialization/UpdaemonJsonContext.cs
+++ b/Updaemon/Serialization/UpdaemonJsonContext.cs
@@ -13,6 +13,7 @@ namespace Updaemon.Serialization
     [JsonSerializable(typeof(Dictionary<string, InstalledPluginInfo>))]
     [JsonSerializable(typeof(Dictionary<string, string>))]
     [JsonSerializable(typeof(AppConfig))]
+    [JsonSerializable(typeof(ServiceType))]
     [JsonSourceGenerationOptions(
         WriteIndented = true,
         PropertyNamingPolicy = JsonKnownNamingPolicy.CamelCase,

--- a/Updaemon/Services/ServiceDeployer.cs
+++ b/Updaemon/Services/ServiceDeployer.cs
@@ -106,7 +106,7 @@ namespace Updaemon.Services
                     string? target = await _symlinkManager.ReadSymlinkAsync(result.SymlinkPath, cancellationToken);
                     if (target == result.VersionDirectory)
                     {
-                        Directory.Delete(result.SymlinkPath, false);
+                        File.Delete(result.SymlinkPath);
                     }
                 }
             }


### PR DESCRIPTION
## Why?

Updaemon currently assumes all registered entries are systemd services. This PR adds support for CLI tools — executables that should be symlinked into PATH rather than managed as systemd units.

## What?

- Adds a `ServiceType` enum (`Service` / `Cli`) to `RegisteredService`, defaulting to `Service` for backwards compatibility with existing configs
- `updaemon new` gains a `--type <service|cli>` flag to register CLI tools
- `updaemon init` creates a `/usr/local/bin` symlink for CLI tools instead of a systemd unit file. When the local name differs from the detected executable name, both a primary symlink (executable name) and an alias symlink (local name) are created
- `updaemon update` skips systemd restart for CLI tools — the existing symlink chain resolves automatically to the new version
- Adds `ServiceType.ToLabel()` extension to centralize human-readable type labels across all commands
- Extracts `NewCommandTestBuilder` to reduce test boilerplate

## Challenges

The symlink naming required a design decision: the binary inside an archive may have a different name than what the user registered (e.g. registering `rg` but the archive contains `ripgrep`). The solution creates both symlinks so either name works, skipping the alias when names already match.