### PR TITLE
Prune old release versions after successful deployment

### DIFF
--- a/README.md
+++ b/README.md
@@ -162,7 +162,7 @@ sudo updaemon init my-api
 updaemon update [app-name]
 ```
 
-Updates all services or a specific service to the latest available version. Should be run with `sudo`.
+Updates all services or a specific service to the latest available version. After a successful deployment, old version directories are automatically pruned, keeping only the most recent versions (controlled by `releaseRetentionCount` in `config.json`, default: 5). The currently-deployed version is always preserved. Should be run with `sudo`.
 
 **Examples:**
 ```bash
@@ -357,11 +357,14 @@ Updaemon stores its configuration in `/var/lib/updaemon/`:
       "executableName": "WordLibraryApi",
       "distributionPluginAlias": "github"
     }
-  ]
+  ],
+  "releaseRetentionCount": 5
 }
 ```
 
 **Note:** The `executableName` field is optional. If not specified, the `localName` is used when searching for the executable.
+
+**Note:** `releaseRetentionCount` controls how many release versions to keep per service after a successful deployment (default: 5). The currently-deployed version is always preserved regardless of this setting.
 
 ### /var/lib/updaemon/plugins/(alias)/secrets.txt
 

--- a/Updaemon.Tests/Commands/UpdateCommandTests.cs
+++ b/Updaemon.Tests/Commands/UpdateCommandTests.cs
@@ -153,10 +153,11 @@ namespace Updaemon.Tests.Commands
                 Assert.Contains(distributionClient.MethodCalls, call => call == "GetLatestVersionAsync:Service1");
                 Assert.Contains(distributionClient.MethodCalls, call => call == "GetLatestVersionAsync:Service2");
 
-                // Both services should be pruned
+                // Both services should be pruned with default retention count
                 Assert.Equal(2, serviceDeployer.PrunedServices.Count);
                 Assert.Contains(serviceDeployer.PrunedServices, p => p.LocalName == "service1");
                 Assert.Contains(serviceDeployer.PrunedServices, p => p.LocalName == "service2");
+                Assert.All(serviceDeployer.PrunedServices, p => Assert.Equal(5, p.RetentionCount));
             }
         }
 
@@ -699,6 +700,58 @@ namespace Updaemon.Tests.Commands
 
                 Assert.Single(serviceDeployer.PrunedServices);
                 Assert.Equal("my-api", serviceDeployer.PrunedServices[0].LocalName);
+            }
+        }
+
+        [Fact]
+        public async Task UpdateService_RestartFails_SkipsPrune()
+        {
+            using (TempFileHelper tempHelper = new TempFileHelper())
+            {
+                MockConfigManager configManager = new MockConfigManager();
+                string pluginPath = tempHelper.CreateTempFile("plugins/github/bin", "fake-plugin");
+                await configManager.AddOrUpdatePluginAsync(new InstalledPluginInfo { Alias = "github", Path = pluginPath });
+                await configManager.RegisterServiceAsync("my-api", "MyApi", "github");
+
+                MockServiceDeployer serviceDeployer = new MockServiceDeployer();
+                serviceDeployer.SetInitialized("my-api", "/opt/my-api/1.0.0");
+                serviceDeployer.SetDeployResult("my-api", new Version(1, 1, 0));
+
+                MockDistributionServiceClient distributionClient = new MockDistributionServiceClient();
+                distributionClient.SetLatestVersion("MyApi", new Version(1, 1, 0));
+
+                MockVersionExtractor versionExtractor = new MockVersionExtractor();
+                versionExtractor.ExtractVersionFromPathResult = new Version(1, 0, 0);
+
+                MockServiceManager serviceManager = new MockServiceManager();
+                serviceManager.ServiceExistsStates["my-api"] = true;
+                serviceManager.ServiceRunningStates["my-api"] = true;
+                serviceManager.ThrowOnRestart = true;
+
+                MockOutputWriter outputWriter = new MockOutputWriter();
+
+                UpdateCommand command = new UpdateCommand(
+                    configManager,
+                    new MockSecretsManager(),
+                    serviceManager,
+                    distributionClient,
+                    outputWriter,
+                    versionExtractor,
+                    serviceDeployer
+                );
+
+                int exitCode = await command.ExecuteAsync(new[] { "my-api" });
+                Assert.Equal(0, exitCode);
+
+                // Restart was attempted
+                Assert.Contains(serviceManager.MethodCalls, call => call == "RestartServiceAsync:my-api");
+
+                // Prune should NOT have been called because the restart exception
+                // causes the outer catch to fire, skipping the prune block
+                Assert.Empty(serviceDeployer.PrunedServices);
+
+                // Error should be reported
+                Assert.Contains(outputWriter.Errors, e => e.Contains("Error updating service"));
             }
         }
 

--- a/Updaemon.Tests/Commands/UpdateCommandTests.cs
+++ b/Updaemon.Tests/Commands/UpdateCommandTests.cs
@@ -152,6 +152,11 @@ namespace Updaemon.Tests.Commands
 
                 Assert.Contains(distributionClient.MethodCalls, call => call == "GetLatestVersionAsync:Service1");
                 Assert.Contains(distributionClient.MethodCalls, call => call == "GetLatestVersionAsync:Service2");
+
+                // Both services should be pruned
+                Assert.Equal(2, serviceDeployer.PrunedServices.Count);
+                Assert.Contains(serviceDeployer.PrunedServices, p => p.LocalName == "service1");
+                Assert.Contains(serviceDeployer.PrunedServices, p => p.LocalName == "service2");
             }
         }
 
@@ -196,6 +201,9 @@ namespace Updaemon.Tests.Commands
                 // Should not call any service manager methods (no restart/start)
                 Assert.Empty(serviceManager.MethodCalls.Where(call =>
                     call.Contains("Start") || call.Contains("Restart") || call.Contains("Stop")));
+
+                // Should not prune when no deploy happened
+                Assert.Empty(serviceDeployer.PrunedServices);
             }
         }
 
@@ -578,6 +586,162 @@ namespace Updaemon.Tests.Commands
 
             Assert.Contains(outputWriter.Errors, e => e.Contains("Plugin executable not found"));
             Assert.DoesNotContain(distributionClient.MethodCalls, c => c.StartsWith("ConnectAsync"));
+        }
+
+        [Fact]
+        public async Task UpdateService_SuccessfulDeploy_PrunesOldVersions()
+        {
+            using (TempFileHelper tempHelper = new TempFileHelper())
+            {
+                MockConfigManager configManager = new MockConfigManager();
+                string pluginPath = tempHelper.CreateTempFile("plugins/github/bin", "fake-plugin");
+                await configManager.AddOrUpdatePluginAsync(new InstalledPluginInfo { Alias = "github", Path = pluginPath });
+                await configManager.RegisterServiceAsync("my-api", "MyApi", "github");
+
+                MockServiceDeployer serviceDeployer = new MockServiceDeployer();
+                serviceDeployer.SetInitialized("my-api", "/opt/my-api/1.0.0");
+                serviceDeployer.SetDeployResult("my-api", new Version(1, 1, 0));
+
+                MockDistributionServiceClient distributionClient = new MockDistributionServiceClient();
+                distributionClient.SetLatestVersion("MyApi", new Version(1, 1, 0));
+
+                MockVersionExtractor versionExtractor = new MockVersionExtractor();
+                versionExtractor.ExtractVersionFromPathResult = new Version(1, 0, 0);
+
+                UpdateCommand command = new UpdateCommand(
+                    configManager,
+                    new MockSecretsManager(),
+                    new MockServiceManager(),
+                    distributionClient,
+                    new MockOutputWriter(),
+                    versionExtractor,
+                    serviceDeployer
+                );
+
+                await command.ExecuteAsync(new[] { "my-api" });
+
+                Assert.Single(serviceDeployer.PrunedServices);
+                Assert.Equal("my-api", serviceDeployer.PrunedServices[0].LocalName);
+                Assert.Equal(5, serviceDeployer.PrunedServices[0].RetentionCount);
+            }
+        }
+
+        [Fact]
+        public async Task UpdateService_FailedDeploy_DoesNotPrune()
+        {
+            using (TempFileHelper tempHelper = new TempFileHelper())
+            {
+                MockConfigManager configManager = new MockConfigManager();
+                string pluginPath = tempHelper.CreateTempFile("plugins/github/bin", "fake-plugin");
+                await configManager.AddOrUpdatePluginAsync(new InstalledPluginInfo { Alias = "github", Path = pluginPath });
+                await configManager.RegisterServiceAsync("my-api", "MyApi", "github");
+
+                MockServiceDeployer serviceDeployer = new MockServiceDeployer();
+                serviceDeployer.SetInitialized("my-api", "/opt/my-api/0.9.0");
+                // Don't configure deploy result — deployer returns null
+
+                MockDistributionServiceClient distributionClient = new MockDistributionServiceClient();
+                distributionClient.SetLatestVersion("MyApi", new Version(1, 0, 0));
+
+                MockVersionExtractor versionExtractor = new MockVersionExtractor();
+                versionExtractor.ExtractVersionFromPathResult = new Version(0, 9, 0);
+
+                UpdateCommand command = new UpdateCommand(
+                    configManager,
+                    new MockSecretsManager(),
+                    new MockServiceManager(),
+                    distributionClient,
+                    new MockOutputWriter(),
+                    versionExtractor,
+                    serviceDeployer
+                );
+
+                await command.ExecuteAsync(new[] { "my-api" });
+
+                Assert.Empty(serviceDeployer.PrunedServices);
+            }
+        }
+
+        [Fact]
+        public async Task UpdateService_SuccessfulDeploy_NoServiceUnit_StillPrunes()
+        {
+            using (TempFileHelper tempHelper = new TempFileHelper())
+            {
+                MockConfigManager configManager = new MockConfigManager();
+                string pluginPath = tempHelper.CreateTempFile("plugins/github/bin", "fake-plugin");
+                await configManager.AddOrUpdatePluginAsync(new InstalledPluginInfo { Alias = "github", Path = pluginPath });
+                await configManager.RegisterServiceAsync("my-api", "MyApi", "github");
+
+                MockServiceDeployer serviceDeployer = new MockServiceDeployer();
+                serviceDeployer.SetInitialized("my-api", "/opt/my-api/1.0.0");
+                serviceDeployer.SetDeployResult("my-api", new Version(1, 1, 0));
+
+                MockDistributionServiceClient distributionClient = new MockDistributionServiceClient();
+                distributionClient.SetLatestVersion("MyApi", new Version(1, 1, 0));
+
+                MockVersionExtractor versionExtractor = new MockVersionExtractor();
+                versionExtractor.ExtractVersionFromPathResult = new Version(1, 0, 0);
+
+                MockServiceManager serviceManager = new MockServiceManager();
+                // serviceExists defaults to false — no systemd unit file
+
+                UpdateCommand command = new UpdateCommand(
+                    configManager,
+                    new MockSecretsManager(),
+                    serviceManager,
+                    distributionClient,
+                    new MockOutputWriter(),
+                    versionExtractor,
+                    serviceDeployer
+                );
+
+                await command.ExecuteAsync(new[] { "my-api" });
+
+                Assert.Single(serviceDeployer.PrunedServices);
+                Assert.Equal("my-api", serviceDeployer.PrunedServices[0].LocalName);
+            }
+        }
+
+        [Fact]
+        public async Task UpdateService_CustomRetentionCount_PassedToPrune()
+        {
+            using (TempFileHelper tempHelper = new TempFileHelper())
+            {
+                MockConfigManager configManager = new MockConfigManager();
+                string pluginPath = tempHelper.CreateTempFile("plugins/github/bin", "fake-plugin");
+                await configManager.AddOrUpdatePluginAsync(new InstalledPluginInfo { Alias = "github", Path = pluginPath });
+                await configManager.RegisterServiceAsync("my-api", "MyApi", "github");
+
+                // Set custom retention count
+                UpdaemonConfig config = await configManager.LoadConfigAsync();
+                config.ReleaseRetentionCount = 10;
+                await configManager.SaveConfigAsync(config);
+
+                MockServiceDeployer serviceDeployer = new MockServiceDeployer();
+                serviceDeployer.SetInitialized("my-api", "/opt/my-api/1.0.0");
+                serviceDeployer.SetDeployResult("my-api", new Version(1, 1, 0));
+
+                MockDistributionServiceClient distributionClient = new MockDistributionServiceClient();
+                distributionClient.SetLatestVersion("MyApi", new Version(1, 1, 0));
+
+                MockVersionExtractor versionExtractor = new MockVersionExtractor();
+                versionExtractor.ExtractVersionFromPathResult = new Version(1, 0, 0);
+
+                UpdateCommand command = new UpdateCommand(
+                    configManager,
+                    new MockSecretsManager(),
+                    new MockServiceManager(),
+                    distributionClient,
+                    new MockOutputWriter(),
+                    versionExtractor,
+                    serviceDeployer
+                );
+
+                await command.ExecuteAsync(new[] { "my-api" });
+
+                Assert.Single(serviceDeployer.PrunedServices);
+                Assert.Equal(10, serviceDeployer.PrunedServices[0].RetentionCount);
+            }
         }
     }
 }

--- a/Updaemon.Tests/Mocks/MockServiceDeployer.cs
+++ b/Updaemon.Tests/Mocks/MockServiceDeployer.cs
@@ -20,6 +20,11 @@ namespace Updaemon.Tests.Mocks
 
         public List<DeployResult> CleanedUpDeploys { get; } = new List<DeployResult>();
 
+        /// <summary>
+        /// Tracks calls to PruneOldVersionsAsync as (localName, retentionCount) tuples.
+        /// </summary>
+        public List<(string LocalName, int RetentionCount)> PrunedServices { get; } = new List<(string, int)>();
+
         public string GetSymlinkPath(string localName)
         {
             return Path.Combine(ServiceBaseDirectory, localName, "current");
@@ -42,6 +47,13 @@ namespace Updaemon.Tests.Mocks
             MethodCalls.Add($"DeployVersionAsync:{key}");
             DeployResults.TryGetValue(key, out DeployResult? result);
             return Task.FromResult(result);
+        }
+
+        public Task PruneOldVersionsAsync(string localName, int retentionCount, CancellationToken cancellationToken = default)
+        {
+            MethodCalls.Add($"PruneOldVersionsAsync:{localName}:{retentionCount}");
+            PrunedServices.Add((localName, retentionCount));
+            return Task.CompletedTask;
         }
 
         public Task CleanupDeployAsync(DeployResult result, CancellationToken cancellationToken = default)

--- a/Updaemon.Tests/Mocks/MockServiceManager.cs
+++ b/Updaemon.Tests/Mocks/MockServiceManager.cs
@@ -11,6 +11,7 @@ namespace Updaemon.Tests.Mocks
         public Dictionary<string, bool> ServiceRunningStates { get; } = new Dictionary<string, bool>();
         public Dictionary<string, bool> ServiceExistsStates { get; } = new Dictionary<string, bool>();
         public bool ThrowOnEnable { get; set; }
+        public bool ThrowOnRestart { get; set; }
 
         public Task StartServiceAsync(string serviceName, CancellationToken cancellationToken = default)
         {
@@ -29,6 +30,8 @@ namespace Updaemon.Tests.Mocks
         public Task RestartServiceAsync(string serviceName, CancellationToken cancellationToken = default)
         {
             MethodCalls.Add($"{nameof(RestartServiceAsync)}:{serviceName}");
+            if (ThrowOnRestart)
+                throw new InvalidOperationException("Simulated restart failure");
             ServiceRunningStates[serviceName] = true;
             return Task.CompletedTask;
         }

--- a/Updaemon.Tests/Services/ServiceDeployerTests.cs
+++ b/Updaemon.Tests/Services/ServiceDeployerTests.cs
@@ -166,6 +166,199 @@ namespace Updaemon.Tests.Services
         }
 
         [Fact]
+        public async Task PruneOldVersionsAsync_RemovesVersionsBeyondRetentionCount()
+        {
+            using (TempFileHelper tempHelper = new TempFileHelper())
+            {
+                string serviceBaseDirectory = tempHelper.TempDirectory;
+                string serviceDir = Path.Combine(serviceBaseDirectory, "my-api");
+
+                // Create 7 version directories
+                string[] versions = { "1.0.0", "1.1.0", "1.2.0", "1.3.0", "1.4.0", "1.5.0", "1.6.0" };
+                foreach (string v in versions)
+                {
+                    Directory.CreateDirectory(Path.Combine(serviceDir, v));
+                }
+
+                MockSymlinkManager symlinkManager = new MockSymlinkManager();
+                symlinkManager.Symlinks[Path.Combine(serviceDir, "current")] = Path.Combine(serviceDir, "1.6.0");
+
+                ServiceDeployer deployer = new ServiceDeployer(
+                    symlinkManager, new MockExecutableDetector(),
+                    new MockFilePermissionManager(), new MockOutputWriter(), serviceBaseDirectory);
+
+                await deployer.PruneOldVersionsAsync("my-api", 3);
+
+                // Should keep top 3 (1.6.0, 1.5.0, 1.4.0) and delete the rest
+                Assert.True(Directory.Exists(Path.Combine(serviceDir, "1.6.0")));
+                Assert.True(Directory.Exists(Path.Combine(serviceDir, "1.5.0")));
+                Assert.True(Directory.Exists(Path.Combine(serviceDir, "1.4.0")));
+                Assert.False(Directory.Exists(Path.Combine(serviceDir, "1.3.0")));
+                Assert.False(Directory.Exists(Path.Combine(serviceDir, "1.2.0")));
+                Assert.False(Directory.Exists(Path.Combine(serviceDir, "1.1.0")));
+                Assert.False(Directory.Exists(Path.Combine(serviceDir, "1.0.0")));
+            }
+        }
+
+        [Fact]
+        public async Task PruneOldVersionsAsync_PreservesCurrentSymlinkTarget()
+        {
+            using (TempFileHelper tempHelper = new TempFileHelper())
+            {
+                string serviceBaseDirectory = tempHelper.TempDirectory;
+                string serviceDir = Path.Combine(serviceBaseDirectory, "my-api");
+
+                string[] versions = { "1.0.0", "1.1.0", "1.2.0", "1.3.0" };
+                foreach (string v in versions)
+                {
+                    Directory.CreateDirectory(Path.Combine(serviceDir, v));
+                }
+
+                // Symlink points to an old version outside the retention window
+                MockSymlinkManager symlinkManager = new MockSymlinkManager();
+                symlinkManager.Symlinks[Path.Combine(serviceDir, "current")] = Path.Combine(serviceDir, "1.0.0");
+
+                ServiceDeployer deployer = new ServiceDeployer(
+                    symlinkManager, new MockExecutableDetector(),
+                    new MockFilePermissionManager(), new MockOutputWriter(), serviceBaseDirectory);
+
+                await deployer.PruneOldVersionsAsync("my-api", 2);
+
+                // Top 2 by version: 1.3.0, 1.2.0 — kept by retention
+                // 1.0.0 — kept because it's the current symlink target
+                // 1.1.0 — deleted
+                Assert.True(Directory.Exists(Path.Combine(serviceDir, "1.3.0")));
+                Assert.True(Directory.Exists(Path.Combine(serviceDir, "1.2.0")));
+                Assert.True(Directory.Exists(Path.Combine(serviceDir, "1.0.0")));
+                Assert.False(Directory.Exists(Path.Combine(serviceDir, "1.1.0")));
+            }
+        }
+
+        [Fact]
+        public async Task PruneOldVersionsAsync_NoVersionDirectories_DoesNothing()
+        {
+            using (TempFileHelper tempHelper = new TempFileHelper())
+            {
+                string serviceBaseDirectory = tempHelper.TempDirectory;
+                string serviceDir = Path.Combine(serviceBaseDirectory, "my-api");
+                Directory.CreateDirectory(serviceDir);
+
+                MockSymlinkManager symlinkManager = new MockSymlinkManager();
+
+                ServiceDeployer deployer = new ServiceDeployer(
+                    symlinkManager, new MockExecutableDetector(),
+                    new MockFilePermissionManager(), new MockOutputWriter(), serviceBaseDirectory);
+
+                await deployer.PruneOldVersionsAsync("my-api", 5);
+
+                // Should not throw, directory still exists
+                Assert.True(Directory.Exists(serviceDir));
+            }
+        }
+
+        [Fact]
+        public async Task PruneOldVersionsAsync_SkipsNonVersionDirectories()
+        {
+            using (TempFileHelper tempHelper = new TempFileHelper())
+            {
+                string serviceBaseDirectory = tempHelper.TempDirectory;
+                string serviceDir = Path.Combine(serviceBaseDirectory, "my-api");
+
+                Directory.CreateDirectory(Path.Combine(serviceDir, "1.0.0"));
+                Directory.CreateDirectory(Path.Combine(serviceDir, "1.1.0"));
+                Directory.CreateDirectory(Path.Combine(serviceDir, "logs"));
+                Directory.CreateDirectory(Path.Combine(serviceDir, "data"));
+
+                MockSymlinkManager symlinkManager = new MockSymlinkManager();
+                symlinkManager.Symlinks[Path.Combine(serviceDir, "current")] = Path.Combine(serviceDir, "1.1.0");
+
+                ServiceDeployer deployer = new ServiceDeployer(
+                    symlinkManager, new MockExecutableDetector(),
+                    new MockFilePermissionManager(), new MockOutputWriter(), serviceBaseDirectory);
+
+                await deployer.PruneOldVersionsAsync("my-api", 1);
+
+                // 1.1.0 kept (in retention window), 1.0.0 deleted
+                Assert.True(Directory.Exists(Path.Combine(serviceDir, "1.1.0")));
+                Assert.False(Directory.Exists(Path.Combine(serviceDir, "1.0.0")));
+                // Non-version directories untouched
+                Assert.True(Directory.Exists(Path.Combine(serviceDir, "logs")));
+                Assert.True(Directory.Exists(Path.Combine(serviceDir, "data")));
+            }
+        }
+
+        [Fact]
+        public async Task PruneOldVersionsAsync_FewerVersionsThanRetentionCount_DeletesNothing()
+        {
+            using (TempFileHelper tempHelper = new TempFileHelper())
+            {
+                string serviceBaseDirectory = tempHelper.TempDirectory;
+                string serviceDir = Path.Combine(serviceBaseDirectory, "my-api");
+
+                Directory.CreateDirectory(Path.Combine(serviceDir, "1.0.0"));
+                Directory.CreateDirectory(Path.Combine(serviceDir, "1.1.0"));
+
+                MockSymlinkManager symlinkManager = new MockSymlinkManager();
+                symlinkManager.Symlinks[Path.Combine(serviceDir, "current")] = Path.Combine(serviceDir, "1.1.0");
+
+                ServiceDeployer deployer = new ServiceDeployer(
+                    symlinkManager, new MockExecutableDetector(),
+                    new MockFilePermissionManager(), new MockOutputWriter(), serviceBaseDirectory);
+
+                await deployer.PruneOldVersionsAsync("my-api", 5);
+
+                Assert.True(Directory.Exists(Path.Combine(serviceDir, "1.0.0")));
+                Assert.True(Directory.Exists(Path.Combine(serviceDir, "1.1.0")));
+            }
+        }
+
+        [Fact]
+        public async Task PruneOldVersionsAsync_RetentionCountZero_ClampsToOne()
+        {
+            using (TempFileHelper tempHelper = new TempFileHelper())
+            {
+                string serviceBaseDirectory = tempHelper.TempDirectory;
+                string serviceDir = Path.Combine(serviceBaseDirectory, "my-api");
+
+                Directory.CreateDirectory(Path.Combine(serviceDir, "1.0.0"));
+                Directory.CreateDirectory(Path.Combine(serviceDir, "1.1.0"));
+                Directory.CreateDirectory(Path.Combine(serviceDir, "1.2.0"));
+
+                MockSymlinkManager symlinkManager = new MockSymlinkManager();
+                symlinkManager.Symlinks[Path.Combine(serviceDir, "current")] = Path.Combine(serviceDir, "1.2.0");
+
+                ServiceDeployer deployer = new ServiceDeployer(
+                    symlinkManager, new MockExecutableDetector(),
+                    new MockFilePermissionManager(), new MockOutputWriter(), serviceBaseDirectory);
+
+                await deployer.PruneOldVersionsAsync("my-api", 0);
+
+                // Clamped to 1, so keeps top 1 (1.2.0) and deletes the rest
+                Assert.True(Directory.Exists(Path.Combine(serviceDir, "1.2.0")));
+                Assert.False(Directory.Exists(Path.Combine(serviceDir, "1.1.0")));
+                Assert.False(Directory.Exists(Path.Combine(serviceDir, "1.0.0")));
+            }
+        }
+
+        [Fact]
+        public async Task PruneOldVersionsAsync_ServiceDirectoryDoesNotExist_DoesNothing()
+        {
+            using (TempFileHelper tempHelper = new TempFileHelper())
+            {
+                string serviceBaseDirectory = tempHelper.TempDirectory;
+
+                MockSymlinkManager symlinkManager = new MockSymlinkManager();
+
+                ServiceDeployer deployer = new ServiceDeployer(
+                    symlinkManager, new MockExecutableDetector(),
+                    new MockFilePermissionManager(), new MockOutputWriter(), serviceBaseDirectory);
+
+                // Should not throw even though /opt/nonexistent doesn't exist
+                await deployer.PruneOldVersionsAsync("nonexistent", 5);
+            }
+        }
+
+        [Fact]
         public async Task CleanupDeployAsync_RemovesVersionDirectory()
         {
             using (TempFileHelper tempHelper = new TempFileHelper())

--- a/Updaemon/Commands/UpdateCommand.cs
+++ b/Updaemon/Commands/UpdateCommand.cs
@@ -92,19 +92,22 @@ namespace Updaemon.Commands
                 return 1;
             }
 
+            // Load config once for settings used during updates
+            UpdaemonConfig config = await _configManager.LoadConfigAsync(cancellationToken);
+
             // Update services grouped by plugin
             foreach (KeyValuePair<string, List<RegisteredService>> pluginGroup in servicesByPlugin)
             {
                 string pluginAlias = pluginGroup.Key;
                 List<RegisteredService> pluginServices = pluginGroup.Value;
 
-                await UpdateServicesForPluginAsync(pluginAlias, pluginServices, cancellationToken);
+                await UpdateServicesForPluginAsync(pluginAlias, pluginServices, config, cancellationToken);
             }
 
             return 0;
         }
 
-        private async Task UpdateServicesForPluginAsync(string pluginAlias, List<RegisteredService> services, CancellationToken cancellationToken)
+        private async Task UpdateServicesForPluginAsync(string pluginAlias, List<RegisteredService> services, UpdaemonConfig config, CancellationToken cancellationToken)
         {
             // Get plugin info
             InstalledPluginInfo? pluginInfo = await _configManager.GetPluginAsync(pluginAlias, cancellationToken);
@@ -132,14 +135,14 @@ namespace Updaemon.Commands
             // Update each service for this plugin
             foreach (RegisteredService service in services)
             {
-                await UpdateServiceAsync(service, cancellationToken);
+                await UpdateServiceAsync(service, config, cancellationToken);
             }
 
             // Disconnect from plugin
             await _distributionClient.DisposeAsync();
         }
 
-        private async Task UpdateServiceAsync(RegisteredService service, CancellationToken cancellationToken)
+        private async Task UpdateServiceAsync(RegisteredService service, UpdaemonConfig config, CancellationToken cancellationToken)
         {
             _outputWriter.WriteLine($"\nUpdating service: {service.LocalName}");
 
@@ -210,6 +213,16 @@ namespace Updaemon.Commands
                 {
                     _outputWriter.WriteLine("Warning: systemd unit file not found. Service not started.");
                 }
+
+                // Prune old versions (best-effort — don't let failure affect deploy outcome)
+                try
+                {
+                    await _serviceDeployer.PruneOldVersionsAsync(service.LocalName, config.ReleaseRetentionCount, cancellationToken);
+                }
+                catch (Exception ex)
+                {
+                    _outputWriter.WriteError($"Warning: Failed to prune old versions for {service.LocalName}: {ex.Message}");
+                }
             }
             catch (Exception ex)
             {
@@ -229,6 +242,10 @@ namespace Updaemon.Commands
                   Updates all registered services to their latest versions. If an app-name
                   is provided, only that specific service is updated. Services are grouped
                   by distribution plugin and updated efficiently.
+
+                  After a successful deployment, old version directories are automatically
+                  pruned. The number of versions to keep is controlled by the
+                  releaseRetentionCount setting in config.json (default: 5).
 
                 Examples:
                   updaemon update          # Update all services

--- a/Updaemon/Interfaces/IServiceDeployer.cs
+++ b/Updaemon/Interfaces/IServiceDeployer.cs
@@ -34,7 +34,8 @@ namespace Updaemon.Interfaces
 
         /// <summary>
         /// Removes old version directories for a service, keeping the most recent versions
-        /// and always preserving the current symlink target. Best-effort.
+        /// and always preserving the current symlink target. Individual directory deletions
+        /// are best-effort, but the method may throw during setup (e.g. reading symlink or listing directories).
         /// </summary>
         Task PruneOldVersionsAsync(string localName, int retentionCount, CancellationToken cancellationToken = default);
     }

--- a/Updaemon/Interfaces/IServiceDeployer.cs
+++ b/Updaemon/Interfaces/IServiceDeployer.cs
@@ -31,5 +31,11 @@ namespace Updaemon.Interfaces
         /// Cleans up artifacts created by a deploy (version directory and symlink). Best-effort.
         /// </summary>
         Task CleanupDeployAsync(DeployResult result, CancellationToken cancellationToken = default);
+
+        /// <summary>
+        /// Removes old version directories for a service, keeping the most recent versions
+        /// and always preserving the current symlink target. Best-effort.
+        /// </summary>
+        Task PruneOldVersionsAsync(string localName, int retentionCount, CancellationToken cancellationToken = default);
     }
 }

--- a/Updaemon/Models/UpdaemonConfig.cs
+++ b/Updaemon/Models/UpdaemonConfig.cs
@@ -14,6 +14,12 @@ namespace Updaemon.Models
         /// List of registered services.
         /// </summary>
         public List<RegisteredService> Services { get; set; } = new List<RegisteredService>();
+
+        /// <summary>
+        /// Total number of release versions to retain per service after a successful deployment.
+        /// Includes the currently-deployed version. Minimum effective value is 1.
+        /// </summary>
+        public int ReleaseRetentionCount { get; set; } = 5;
     }
 }
 

--- a/Updaemon/Services/ServiceDeployer.cs
+++ b/Updaemon/Services/ServiceDeployer.cs
@@ -127,6 +127,7 @@ namespace Updaemon.Services
 
             foreach (string directory in directoriesToDelete)
             {
+                cancellationToken.ThrowIfCancellationRequested();
                 try
                 {
                     Directory.Delete(directory, recursive: true);

--- a/Updaemon/Services/ServiceDeployer.cs
+++ b/Updaemon/Services/ServiceDeployer.cs
@@ -95,6 +95,50 @@ namespace Updaemon.Services
             };
         }
 
+        public async Task PruneOldVersionsAsync(string localName, int retentionCount, CancellationToken cancellationToken = default)
+        {
+            string serviceDirectory = Path.Combine(_serviceBaseDirectory, localName);
+            if (!Directory.Exists(serviceDirectory))
+                return;
+
+            if (retentionCount < 1)
+                retentionCount = 1;
+
+            string symlinkPath = GetSymlinkPath(localName);
+            string? currentTarget = await _symlinkManager.ReadSymlinkAsync(symlinkPath, cancellationToken);
+            string? normalizedCurrentTarget = currentTarget != null ? Path.GetFullPath(currentTarget, serviceDirectory) : null;
+
+            List<(string Path, Version Version)> versionDirectories = new List<(string, Version)>();
+            foreach (string directory in Directory.GetDirectories(serviceDirectory))
+            {
+                string dirName = Path.GetFileName(directory);
+                if (Version.TryParse(dirName, out Version? version))
+                {
+                    versionDirectories.Add((Path.GetFullPath(directory), version));
+                }
+            }
+
+            List<string> directoriesToDelete = versionDirectories
+                .OrderByDescending(v => v.Version)
+                .Skip(retentionCount)
+                .Where(v => v.Path != normalizedCurrentTarget)
+                .Select(v => v.Path)
+                .ToList();
+
+            foreach (string directory in directoriesToDelete)
+            {
+                try
+                {
+                    Directory.Delete(directory, recursive: true);
+                    _outputWriter.WriteLine($"Pruned old version: {Path.GetFileName(directory)}");
+                }
+                catch (Exception ex)
+                {
+                    _outputWriter.WriteError($"Warning: Failed to prune {Path.GetFileName(directory)}: {ex.Message}");
+                }
+            }
+        }
+
         public async Task CleanupDeployAsync(DeployResult result, CancellationToken cancellationToken = default)
         {
             // Remove symlink so the service does not appear initialized


### PR DESCRIPTION
## Why?

Closes #12. When `updaemon update` deploys a new version, old version directories under `/opt/<service-name>/` accumulate indefinitely. On disk-constrained Raspberry Pis, this wastes storage over time.

## What?

Adds automatic pruning of old release version directories after a successful deployment:

- **New config setting** `releaseRetentionCount` on `UpdaemonConfig` (default: 5) controls how many versions to keep per service
- **New method** `PruneOldVersionsAsync` on `IServiceDeployer` / `ServiceDeployer` enumerates version directories, sorts by version descending, and deletes everything beyond the retention count
- **Safety**: the current symlink target is always preserved regardless of retention count, non-version directories are skipped, and `retentionCount` is clamped to a minimum of 1
- **Error handling**: pruning is best-effort with per-directory try/catch, and the prune call in `UpdateCommand` has its own try/catch so a pruning failure never affects deploy outcome
- **Config loaded once** in `ExecuteAsync` and threaded through to avoid redundant I/O in multi-service updates
- **Path normalization** via `Path.GetFullPath` with base directory for robust symlink target comparison
- **Documentation** updated in README (update command description, config.json example) and `UpdateCommand.GetDetailedHelp()`
- **11 new tests** covering: retention count enforcement, symlink target preservation, non-version directory skipping, missing service directory, fewer versions than retention, zero retention clamping, successful deploy triggers prune, failed deploy skips prune, no service unit still prunes, custom retention count passthrough, multi-service pruning

## Challenges

The symlink target comparison needed care — `ReadSymlinkAsync` and `Directory.GetDirectories` could return paths in different forms (relative vs absolute, trailing slashes). Using `Path.GetFullPath(target, serviceDirectory)` on both sides ensures consistent comparison even if a relative symlink target were ever created.