### PR TITLE
Add list command to show registered applications

### DIFF
--- a/README.md
+++ b/README.md
@@ -121,6 +121,7 @@ Commands that change files in the system usually require `sudo` to run.
 | --- | --- |
 | [new](#new-command) | Register a new managed service. |
 | [init](#init-command) | Download and set up a registered service for the first time. |
+| [list](#list-command) | List all registered applications with version and status. |
 | [update](#update-command) | Update all or a specific service to the latest version. |
 | [set-remote](#set-remote-command) | Set the remote name used by the distribution plugin. |
 | [set-exec-name](#set-exec-command) | Set or clear the executable name for a service. |
@@ -155,6 +156,14 @@ Downloads and sets up a registered service for the first time. This command down
 ```bash
 sudo updaemon init my-api
 ```
+
+### List Command
+
+```bash
+updaemon list
+```
+
+Lists all registered applications (services and CLI tools) with their current version, initialization status, type, distribution plugin, and remote name.
 
 ### Update Command
 

--- a/Updaemon.Tests/Commands/ListCommandTests.cs
+++ b/Updaemon.Tests/Commands/ListCommandTests.cs
@@ -1,0 +1,105 @@
+using Updaemon.Commands;
+using Updaemon.Models;
+using Updaemon.Tests.Helpers;
+using Updaemon.Tests.Mocks;
+
+namespace Updaemon.Tests.Commands
+{
+    public class ListCommandTests
+    {
+        private readonly MockConfigManager _configManager = new MockConfigManager();
+        private readonly MockOutputWriter _output = new MockOutputWriter();
+        private readonly MockServiceDeployer _serviceDeployer = new MockServiceDeployer();
+        private readonly TestVersionExtractor _versionExtractor = new TestVersionExtractor();
+
+        private ListCommand CreateCommand()
+        {
+            return new ListCommand(_configManager, _output, _serviceDeployer, _versionExtractor);
+        }
+
+        [Fact]
+        public async Task ExecuteAsync_WhenNoServicesRegistered_ShowsEmptyMessage()
+        {
+            ListCommand command = CreateCommand();
+            int exitCode = await command.ExecuteAsync(Array.Empty<string>());
+
+            Assert.Equal(0, exitCode);
+            Assert.Contains(_output.Messages, line => line.Contains("No applications registered."));
+            Assert.Contains(_output.Messages, line => line.Contains("updaemon new <app-name> --from"));
+        }
+
+        [Fact]
+        public async Task ExecuteAsync_WithSingleInitializedService_ShowsVersionAndDetails()
+        {
+            await _configManager.RegisterServiceAsync("my-api", "my-org/my-api", "github", ServiceType.Service);
+            _serviceDeployer.SetInitialized("my-api", "/opt/my-api/2.1.0");
+
+            ListCommand command = CreateCommand();
+            int exitCode = await command.ExecuteAsync(Array.Empty<string>());
+
+            Assert.Equal(0, exitCode);
+            Assert.Contains(_output.Messages, line => line.Contains("Registered applications (1):"));
+            Assert.Contains(_output.Messages, line => line.Contains("Name: my-api"));
+            Assert.Contains(_output.Messages, line => line.Contains("Type: service"));
+            Assert.Contains(_output.Messages, line => line.Contains("Version: 2.1.0"));
+            Assert.Contains(_output.Messages, line => line.Contains("Distribution plugin: github"));
+            Assert.Contains(_output.Messages, line => line.Contains("Remote name: my-org/my-api"));
+        }
+
+        [Fact]
+        public async Task ExecuteAsync_WithUninitializedService_ShowsNotInitialized()
+        {
+            await _configManager.RegisterServiceAsync("my-api", "my-org/my-api", "github");
+
+            ListCommand command = CreateCommand();
+            int exitCode = await command.ExecuteAsync(Array.Empty<string>());
+
+            Assert.Equal(0, exitCode);
+            Assert.Contains(_output.Messages, line => line.Contains("Version: not initialized"));
+        }
+
+        [Fact]
+        public async Task ExecuteAsync_WithCliTool_ShowsCliToolType()
+        {
+            await _configManager.RegisterServiceAsync("my-tool", "my-org/my-tool", "github", ServiceType.Cli);
+            _serviceDeployer.SetInitialized("my-tool", "/opt/my-tool/1.0.0");
+
+            ListCommand command = CreateCommand();
+            int exitCode = await command.ExecuteAsync(Array.Empty<string>());
+
+            Assert.Equal(0, exitCode);
+            Assert.Contains(_output.Messages, line => line.Contains("Type: CLI tool"));
+        }
+
+        [Fact]
+        public async Task ExecuteAsync_WithMixedInitializedAndUninitialized_ShowsBoth()
+        {
+            await _configManager.RegisterServiceAsync("app-a", "org/app-a", "github");
+            await _configManager.RegisterServiceAsync("app-b", "org/app-b", "github");
+            _serviceDeployer.SetInitialized("app-a", "/opt/app-a/1.0.0");
+
+            ListCommand command = CreateCommand();
+            int exitCode = await command.ExecuteAsync(Array.Empty<string>());
+
+            Assert.Equal(0, exitCode);
+            Assert.Contains(_output.Messages, line => line.Contains("Registered applications (2):"));
+            Assert.Contains(_output.Messages, line => line.Contains("Name: app-a"));
+            Assert.Contains(_output.Messages, line => line.Contains("Name: app-b"));
+            Assert.Contains(_output.Messages, line => line.Contains("Version: 1.0.0"));
+            Assert.Contains(_output.Messages, line => line.Contains("Version: not initialized"));
+        }
+
+        [Fact]
+        public async Task ExecuteAsync_WhenVersionCannotBeExtracted_ShowsUnknown()
+        {
+            await _configManager.RegisterServiceAsync("my-api", "my-org/my-api", "github");
+            _serviceDeployer.SetInitialized("my-api", "/opt/my-api/current");
+
+            ListCommand command = CreateCommand();
+            int exitCode = await command.ExecuteAsync(Array.Empty<string>());
+
+            Assert.Equal(0, exitCode);
+            Assert.Contains(_output.Messages, line => line.Contains("Version: unknown"));
+        }
+    }
+}

--- a/Updaemon/Commands/CommandFactory.cs
+++ b/Updaemon/Commands/CommandFactory.cs
@@ -19,6 +19,7 @@ namespace Updaemon.Commands
             {
                 ["new"] = typeof(NewCommand),
                 ["init"] = typeof(InitCommand),
+                ["list"] = typeof(ListCommand),
                 ["update"] = typeof(UpdateCommand),
                 ["set-remote"] = typeof(SetRemoteCommand),
                 ["set-exec-name"] = typeof(SetExecNameCommand),

--- a/Updaemon/Commands/ListCommand.cs
+++ b/Updaemon/Commands/ListCommand.cs
@@ -1,0 +1,88 @@
+using Updaemon.Interfaces;
+using Updaemon.Models;
+
+namespace Updaemon.Commands
+{
+    /// <summary>
+    /// Handles the 'list' command to list all registered applications.
+    /// </summary>
+    public class ListCommand : ICommand
+    {
+        private readonly IConfigManager _configManager;
+        private readonly IOutputWriter _outputWriter;
+        private readonly IServiceDeployer _serviceDeployer;
+        private readonly IVersionExtractor _versionExtractor;
+
+        public ListCommand(IConfigManager configManager, IOutputWriter outputWriter, IServiceDeployer serviceDeployer, IVersionExtractor versionExtractor)
+        {
+            _configManager = configManager;
+            _outputWriter = outputWriter;
+            _serviceDeployer = serviceDeployer;
+            _versionExtractor = versionExtractor;
+        }
+
+        public string Name => "list";
+
+        public string Description => "List all registered applications";
+
+        public string Usage => "updaemon list";
+
+        public async Task<int> ExecuteAsync(string[] args, CancellationToken cancellationToken = default)
+        {
+            IReadOnlyList<RegisteredService> services = await _configManager.GetAllServicesAsync(cancellationToken);
+
+            if (services.Count == 0)
+            {
+                _outputWriter.WriteLine("No applications registered.");
+                _outputWriter.WriteLine("Use 'updaemon new <app-name> --from <plugin-alias>' to register one.");
+                return 0;
+            }
+
+            _outputWriter.WriteLine($"Registered applications ({services.Count}):");
+            _outputWriter.WriteLine("");
+
+            foreach (RegisteredService service in services)
+            {
+                string? currentTarget = await _serviceDeployer.ReadCurrentTargetAsync(service.LocalName, cancellationToken);
+                string versionDisplay;
+
+                if (currentTarget == null)
+                {
+                    versionDisplay = "not initialized";
+                }
+                else
+                {
+                    Version? version = _versionExtractor.ExtractVersionFromPath(currentTarget);
+                    versionDisplay = version?.ToString() ?? "unknown";
+                }
+
+                _outputWriter.WriteLine($"  Name: {service.LocalName}");
+                _outputWriter.WriteLine($"  Type: {service.ServiceType.ToLabel()}");
+                _outputWriter.WriteLine($"  Version: {versionDisplay}");
+                _outputWriter.WriteLine($"  Distribution plugin: {service.DistributionPluginAlias}");
+                _outputWriter.WriteLine($"  Remote name: {service.RemoteName}");
+                _outputWriter.WriteLine("");
+            }
+
+            return 0;
+        }
+
+        public string GetDetailedHelp()
+        {
+            return """
+                List Command
+
+                Usage:
+                  updaemon list
+
+                Description:
+                  Lists all registered applications (services and CLI tools) with their
+                  current version, initialization status, type, distribution plugin,
+                  and remote name.
+
+                Examples:
+                  updaemon list
+                """;
+        }
+    }
+}

--- a/Updaemon/Program.cs
+++ b/Updaemon/Program.cs
@@ -75,6 +75,7 @@ namespace Updaemon
             // Commands - transient (created per invocation)
             services.AddTransient<NewCommand>();
             services.AddTransient<InitCommand>();
+            services.AddTransient<ListCommand>();
             services.AddTransient<UpdateCommand>();
             services.AddTransient<SetRemoteCommand>();
             services.AddTransient<SetExecNameCommand>();


### PR DESCRIPTION
## Why?
Closes #10. There was no way to see which applications updaemon is currently managing.

## What?
Adds an `updaemon list` command that displays all registered applications (services and CLI tools) with:
- Name and type (service or CLI tool)
- Current version, or "not initialized" / "unknown"
- Distribution plugin and remote name

Includes 6 tests covering empty state, initialized/uninitialized services, CLI tools, mixed entries, and unparseable version paths. README updated with command table entry and section.