### PR TITLE
Add per-service opt-out for auto-restart after update

### DIFF
--- a/README.md
+++ b/README.md
@@ -127,6 +127,7 @@ Commands that change files in the system usually require `sudo` to run.
 | [update](#update-command) | Update all or a specific service to the latest version. |
 | [set-remote](#set-remote-command) | Set the remote name used by the distribution plugin. |
 | [set-exec-name](#set-exec-command) | Set or clear the executable name for a service. |
+| [set-restart](#set-restart-command) | Set restart behavior after update (auto/manual). |
 | [dist-install](#dist-install-command) | Download and install a distribution plugin (supports `--as`). |
 | [dist-update](#dist-update-command) | Update installed distribution plugins. |
 | [dist-list](#dist-list-command) | List installed distribution plugins and their metadata. |
@@ -165,7 +166,7 @@ sudo updaemon init my-api
 updaemon list
 ```
 
-Lists all registered applications (services and CLI tools) with their current version, initialization status, type, distribution plugin, and remote name.
+Lists all registered applications (services and CLI tools) with their current version, initialization status, type, distribution plugin, and remote name. For services, the restart behavior (`auto` or `manual`) is also shown.
 
 ### Update Command
 
@@ -174,6 +175,8 @@ updaemon update [app-name]
 ```
 
 Updates all services or a specific service to the latest available version. After a successful deployment, old version directories are automatically pruned, keeping only the most recent versions (controlled by `releaseRetentionCount` in `config.json`, default: 5). The currently-deployed version is always preserved. Should be run with `sudo`.
+
+By default, a service is restarted after a new version is deployed. A service whose restart behavior is set to `manual` (see [set-restart](#set-restart-command)) is deployed but **not** restarted — the running process keeps the previous version until it restarts on its own.
 
 **Examples:**
 ```bash
@@ -215,6 +218,28 @@ sudo updaemon set-exec-name my-api MyApi
 
 # Clear executable name
 sudo updaemon set-exec-name my-api -
+```
+
+### Set-Restart Command
+
+```bash
+updaemon set-restart <app-name> auto|manual
+```
+
+Controls whether a service is restarted after `update` deploys a new version.
+
+- `auto` (default): restart the service after deploying a new version.
+- `manual`: deploy the new version (download, repoint the symlink, prune old versions) but leave the running process untouched. The service keeps running the previous version until it restarts — useful when the application wants to apply the update on demand (e.g. show a "restart to apply" prompt and exit gracefully under `Restart=always` / `KeepAlive=true`).
+
+Only meaningful for services; CLI tools are never restarted.
+
+**Examples:**
+```bash
+# Deploy without restarting; the app restarts on demand
+sudo updaemon set-restart my-api manual
+
+# Restore the default restart-after-update behavior
+sudo updaemon set-restart my-api auto
 ```
 
 ### Dist-Install Command
@@ -394,7 +419,8 @@ The directory contains:
       "localName": "word-library-api",
       "remoteName": "FastPackages.WordLibraryApi",
       "executableName": "WordLibraryApi",
-      "distributionPluginAlias": "github"
+      "distributionPluginAlias": "github",
+      "autoRestart": true
     }
   ],
   "releaseRetentionCount": 5
@@ -402,6 +428,8 @@ The directory contains:
 ```
 
 **Note:** The `executableName` field is optional. If not specified, the `localName` is used when searching for the executable.
+
+**Note:** The `autoRestart` field (default `true`) controls whether a service is restarted after `update` deploys a new version. Set it to `false` (via `updaemon set-restart <app-name> manual`) to deploy without restarting. A missing field is treated as `true`, so existing configs are unaffected.
 
 **Note:** `releaseRetentionCount` controls how many release versions to keep per service after a successful deployment (default: 5). The currently-deployed version is always preserved regardless of this setting.
 

--- a/Updaemon.Tests/Commands/ListCommandTests.cs
+++ b/Updaemon.Tests/Commands/ListCommandTests.cs
@@ -72,6 +72,46 @@ namespace Updaemon.Tests.Commands
         }
 
         [Fact]
+        public async Task ExecuteAsync_ServiceWithDefaultRestart_ShowsRestartAuto()
+        {
+            await _configManager.RegisterServiceAsync("my-api", "my-org/my-api", "github", ServiceType.Service);
+            _serviceDeployer.SetInitialized("my-api", "/opt/my-api/1.0.0");
+
+            ListCommand command = CreateCommand();
+            int exitCode = await command.ExecuteAsync(Array.Empty<string>());
+
+            Assert.Equal(0, exitCode);
+            Assert.Contains(_output.Messages, line => line.Contains("Restart: auto"));
+        }
+
+        [Fact]
+        public async Task ExecuteAsync_ServiceWithManualRestart_ShowsRestartManual()
+        {
+            await _configManager.RegisterServiceAsync("my-api", "my-org/my-api", "github", ServiceType.Service);
+            await _configManager.SetAutoRestartAsync("my-api", false);
+            _serviceDeployer.SetInitialized("my-api", "/opt/my-api/1.0.0");
+
+            ListCommand command = CreateCommand();
+            int exitCode = await command.ExecuteAsync(Array.Empty<string>());
+
+            Assert.Equal(0, exitCode);
+            Assert.Contains(_output.Messages, line => line.Contains("Restart: manual"));
+        }
+
+        [Fact]
+        public async Task ExecuteAsync_CliTool_DoesNotShowRestart()
+        {
+            await _configManager.RegisterServiceAsync("my-tool", "my-org/my-tool", "github", ServiceType.Cli);
+            _serviceDeployer.SetInitialized("my-tool", "/opt/my-tool/1.0.0");
+
+            ListCommand command = CreateCommand();
+            int exitCode = await command.ExecuteAsync(Array.Empty<string>());
+
+            Assert.Equal(0, exitCode);
+            Assert.DoesNotContain(_output.Messages, line => line.Contains("Restart:"));
+        }
+
+        [Fact]
         public async Task ExecuteAsync_WithMixedInitializedAndUninitialized_ShowsBoth()
         {
             await _configManager.RegisterServiceAsync("app-a", "org/app-a", "github");

--- a/Updaemon.Tests/Commands/SetRestartCommandTests.cs
+++ b/Updaemon.Tests/Commands/SetRestartCommandTests.cs
@@ -1,0 +1,109 @@
+using Updaemon.Commands;
+using Updaemon.Models;
+using Updaemon.Tests.Mocks;
+
+namespace Updaemon.Tests.Commands
+{
+    public class SetRestartCommandTests
+    {
+        [Fact]
+        public async Task ExecuteAsync_Auto_SetsAutoRestartTrueViaConfigManager()
+        {
+            MockConfigManager configManager = new MockConfigManager();
+            MockOutputWriter outputWriter = new MockOutputWriter();
+            SetRestartCommand command = new SetRestartCommand(configManager, outputWriter);
+
+            await configManager.RegisterServiceAsync("my-api", "MyApi", "github");
+            int exitCode = await command.ExecuteAsync(new[] { "my-api", "auto" });
+
+            Assert.Equal(0, exitCode);
+            Assert.Contains(configManager.MethodCalls, call => call == "SetAutoRestartAsync:my-api:True");
+
+            // A regular service should not get the CLI-only note.
+            Assert.DoesNotContain(outputWriter.Messages, m => m.Contains("no effect for CLI tools"));
+        }
+
+        [Fact]
+        public async Task ExecuteAsync_Manual_SetsAutoRestartFalseViaConfigManager()
+        {
+            MockConfigManager configManager = new MockConfigManager();
+            MockOutputWriter outputWriter = new MockOutputWriter();
+            SetRestartCommand command = new SetRestartCommand(configManager, outputWriter);
+
+            await configManager.RegisterServiceAsync("my-api", "MyApi", "github");
+            int exitCode = await command.ExecuteAsync(new[] { "my-api", "manual" });
+
+            Assert.Equal(0, exitCode);
+            Assert.Contains(configManager.MethodCalls, call => call == "SetAutoRestartAsync:my-api:False");
+        }
+
+        [Fact]
+        public async Task ExecuteAsync_ModeIsCaseInsensitive()
+        {
+            MockConfigManager configManager = new MockConfigManager();
+            MockOutputWriter outputWriter = new MockOutputWriter();
+            SetRestartCommand command = new SetRestartCommand(configManager, outputWriter);
+
+            await configManager.RegisterServiceAsync("my-api", "MyApi", "github");
+            int exitCode = await command.ExecuteAsync(new[] { "my-api", "MANUAL" });
+
+            Assert.Equal(0, exitCode);
+            Assert.Contains(configManager.MethodCalls, call => call == "SetAutoRestartAsync:my-api:False");
+        }
+
+        [Fact]
+        public async Task ExecuteAsync_InvalidMode_ReturnsErrorCodeAndDoesNotSet()
+        {
+            MockConfigManager configManager = new MockConfigManager();
+            MockOutputWriter outputWriter = new MockOutputWriter();
+            SetRestartCommand command = new SetRestartCommand(configManager, outputWriter);
+
+            await configManager.RegisterServiceAsync("my-api", "MyApi", "github");
+            int exitCode = await command.ExecuteAsync(new[] { "my-api", "sometimes" });
+
+            Assert.Equal(1, exitCode);
+            Assert.Contains(outputWriter.Errors, e => e.Contains("Invalid restart mode"));
+            Assert.DoesNotContain(configManager.MethodCalls, call => call.StartsWith("SetAutoRestartAsync"));
+        }
+
+        [Fact]
+        public async Task ExecuteAsync_ServiceDoesNotExist_ReturnsErrorCode()
+        {
+            MockConfigManager configManager = new MockConfigManager();
+            MockOutputWriter outputWriter = new MockOutputWriter();
+            SetRestartCommand command = new SetRestartCommand(configManager, outputWriter);
+
+            int exitCode = await command.ExecuteAsync(new[] { "non-existent", "manual" });
+
+            Assert.Equal(1, exitCode);
+            Assert.Contains(outputWriter.Errors, e => e.Contains("not registered"));
+        }
+
+        [Fact]
+        public async Task ExecuteAsync_WithoutRequiredArgs_ReturnsErrorCode()
+        {
+            MockConfigManager configManager = new MockConfigManager();
+            MockOutputWriter outputWriter = new MockOutputWriter();
+            SetRestartCommand command = new SetRestartCommand(configManager, outputWriter);
+
+            int exitCode = await command.ExecuteAsync(new[] { "app-name" });
+
+            Assert.Equal(1, exitCode);
+            Assert.Contains(outputWriter.Errors, e => e.Contains("Insufficient arguments"));
+        }
+
+        [Fact]
+        public async Task ExecuteAsync_CliTool_WarnsSettingHasNoEffect()
+        {
+            MockConfigManager configManager = new MockConfigManager();
+            MockOutputWriter outputWriter = new MockOutputWriter();
+            SetRestartCommand command = new SetRestartCommand(configManager, outputWriter);
+
+            await configManager.RegisterServiceAsync("my-tool", "MyTool", "github", ServiceType.Cli);
+            int exitCode = await command.ExecuteAsync(new[] { "my-tool", "manual" });
+
+            Assert.Equal(0, exitCode);
+            Assert.Contains(outputWriter.Messages, m => m.Contains("no effect for CLI tools"));
+        }
+    }
+}

--- a/Updaemon.Tests/Commands/UpdateCommandTests.cs
+++ b/Updaemon.Tests/Commands/UpdateCommandTests.cs
@@ -289,6 +289,67 @@ namespace Updaemon.Tests.Commands
         }
 
         [Fact]
+        public async Task UpdateService_AutoRestartManual_DeploysButDoesNotRestart()
+        {
+            using (TempFileHelper tempHelper = new TempFileHelper())
+            {
+                MockConfigManager configManager = new MockConfigManager();
+                string pluginPath = tempHelper.CreateTempFile("plugins/github/bin", "fake-plugin");
+                InstalledPluginInfo pluginInfo = new InstalledPluginInfo { Alias = "github", Path = pluginPath };
+                await configManager.AddOrUpdatePluginAsync(pluginInfo);
+                await configManager.RegisterServiceAsync("my-api", "MyApi", "github");
+
+                // Opt the service out of auto-restart.
+                UpdaemonConfig config = await configManager.LoadConfigAsync();
+                config.Services.First(s => s.LocalName == "my-api").AutoRestart = false;
+                await configManager.SaveConfigAsync(config);
+
+                MockServiceDeployer serviceDeployer = new MockServiceDeployer();
+                serviceDeployer.SetInitialized("my-api", "/opt/my-api/1.0.0");
+                serviceDeployer.SetDeployResult("my-api", new Version(1, 1, 0));
+
+                MockDistributionServiceClient distributionClient = new MockDistributionServiceClient();
+                distributionClient.SetLatestVersion("MyApi", new Version(1, 1, 0));
+
+                MockVersionExtractor versionExtractor = new MockVersionExtractor();
+                versionExtractor.ExtractVersionFromPathResult = new Version(1, 0, 0);
+
+                MockServiceManager serviceManager = new MockServiceManager();
+                serviceManager.ServiceExistsStates["my-api"] = true;
+                serviceManager.ServiceRunningStates["my-api"] = true;
+
+                MockOutputWriter outputWriter = new MockOutputWriter();
+
+                UpdateCommand command = new UpdateCommand(
+                    configManager,
+                    new MockSecretsManager(),
+                    serviceManager,
+                    distributionClient,
+                    outputWriter,
+                    versionExtractor,
+                    serviceDeployer
+                );
+
+                int exitCode = await command.ExecuteAsync(new[] { "my-api" });
+                Assert.Equal(0, exitCode);
+
+                // New version was deployed.
+                Assert.Contains(serviceDeployer.MethodCalls, call => call == "DeployVersionAsync:my-api:1.1.0");
+
+                // The running process was left untouched — neither restart nor start.
+                Assert.Empty(serviceManager.MethodCalls.Where(call =>
+                    call.Contains("Start") || call.Contains("Restart")));
+
+                // Skip is communicated to the user.
+                Assert.Contains(outputWriter.Messages, m => m.Contains("restart skipped"));
+
+                // Prune still runs after a deploy-only update.
+                Assert.Single(serviceDeployer.PrunedServices);
+                Assert.Equal("my-api", serviceDeployer.PrunedServices[0].LocalName);
+            }
+        }
+
+        [Fact]
         public async Task UpdateService_StartsStoppedService()
         {
             using (TempFileHelper tempHelper = new TempFileHelper())

--- a/Updaemon.Tests/Configuration/ConfigManagerTests.cs
+++ b/Updaemon.Tests/Configuration/ConfigManagerTests.cs
@@ -356,6 +356,75 @@ namespace Updaemon.Tests.Configuration
         }
 
         [Fact]
+        public async Task SetAutoRestartAsync_UpdatesValue()
+        {
+            using (TempFileHelper tempHelper = new TempFileHelper())
+            {
+                ConfigManager configManager = new ConfigManager(tempHelper.TempDirectory);
+
+                await configManager.RegisterServiceAsync("my-api", "MyApi", "github");
+
+                // Defaults to true for a freshly registered service.
+                RegisteredService? service = await configManager.GetServiceAsync("my-api");
+                Assert.NotNull(service);
+                Assert.True(service.AutoRestart);
+
+                await configManager.SetAutoRestartAsync("my-api", false);
+                service = await configManager.GetServiceAsync("my-api");
+                Assert.NotNull(service);
+                Assert.False(service.AutoRestart);
+
+                await configManager.SetAutoRestartAsync("my-api", true);
+                service = await configManager.GetServiceAsync("my-api");
+                Assert.NotNull(service);
+                Assert.True(service.AutoRestart);
+            }
+        }
+
+        [Fact]
+        public async Task SetAutoRestartAsync_ServiceDoesNotExist_ThrowsException()
+        {
+            using (TempFileHelper tempHelper = new TempFileHelper())
+            {
+                ConfigManager configManager = new ConfigManager(tempHelper.TempDirectory);
+
+                InvalidOperationException exception = await Assert.ThrowsAsync<InvalidOperationException>(
+                    async () => await configManager.SetAutoRestartAsync("non-existent", false)
+                );
+
+                Assert.Contains("not registered", exception.Message);
+            }
+        }
+
+        [Fact]
+        public async Task LoadConfigAsync_OldConfigWithoutAutoRestart_DefaultsToTrue()
+        {
+            using (TempFileHelper tempHelper = new TempFileHelper())
+            {
+                string configPath = Path.Combine(tempHelper.TempDirectory, "config.json");
+                string oldConfigJson = @"{
+  ""installedPlugins"": {},
+  ""services"": [
+    {
+      ""localName"": ""test-service"",
+      ""remoteName"": ""TestService"",
+      ""distributionPluginAlias"": ""github""
+    }
+  ]
+}";
+                Directory.CreateDirectory(tempHelper.TempDirectory);
+                await File.WriteAllTextAsync(configPath, oldConfigJson);
+
+                ConfigManager configManager = new ConfigManager(tempHelper.TempDirectory);
+                UpdaemonConfig config = await configManager.LoadConfigAsync();
+
+                Assert.NotNull(config);
+                Assert.Single(config.Services);
+                Assert.True(config.Services[0].AutoRestart);
+            }
+        }
+
+        [Fact]
         public async Task RegisterServiceAsync_WithCliType_PersistsType()
         {
             using (TempFileHelper tempHelper = new TempFileHelper())

--- a/Updaemon.Tests/Mocks/MockConfigManager.cs
+++ b/Updaemon.Tests/Mocks/MockConfigManager.cs
@@ -76,6 +76,21 @@ namespace Updaemon.Tests.Mocks
             await SaveConfigAsync(config, cancellationToken);
         }
 
+        public async Task SetAutoRestartAsync(string localName, bool autoRestart, CancellationToken cancellationToken = default)
+        {
+            MethodCalls.Add($"{nameof(SetAutoRestartAsync)}:{localName}:{autoRestart}");
+            UpdaemonConfig config = await LoadConfigAsync(cancellationToken);
+
+            RegisteredService? service = config.Services.FirstOrDefault(s => s.LocalName == localName);
+            if (service == null)
+            {
+                throw new InvalidOperationException($"Service '{localName}' is not registered.");
+            }
+
+            service.AutoRestart = autoRestart;
+            await SaveConfigAsync(config, cancellationToken);
+        }
+
         public async Task<RegisteredService?> GetServiceAsync(string localName, CancellationToken cancellationToken = default)
         {
             MethodCalls.Add($"{nameof(GetServiceAsync)}:{localName}");

--- a/Updaemon/Commands/CommandFactory.cs
+++ b/Updaemon/Commands/CommandFactory.cs
@@ -23,6 +23,7 @@ namespace Updaemon.Commands
                 ["update"] = typeof(UpdateCommand),
                 ["set-remote"] = typeof(SetRemoteCommand),
                 ["set-exec-name"] = typeof(SetExecNameCommand),
+                ["set-restart"] = typeof(SetRestartCommand),
                 ["dist-install"] = typeof(DistInstallCommand),
                 ["dist-update"] = typeof(DistUpdateCommand),
                 ["dist-list"] = typeof(DistListCommand),

--- a/Updaemon/Commands/ListCommand.cs
+++ b/Updaemon/Commands/ListCommand.cs
@@ -58,6 +58,10 @@ namespace Updaemon.Commands
 
                 _outputWriter.WriteLine($"  Name: {service.LocalName}");
                 _outputWriter.WriteLine($"  Type: {service.ServiceType.ToLabel()}");
+                if (service.ServiceType == ServiceType.Service)
+                {
+                    _outputWriter.WriteLine($"  Restart: {(service.AutoRestart ? "auto" : "manual")}");
+                }
                 _outputWriter.WriteLine($"  Version: {versionDisplay}");
                 _outputWriter.WriteLine($"  Distribution plugin: {service.DistributionPluginAlias}");
                 _outputWriter.WriteLine($"  Remote name: {service.RemoteName}");

--- a/Updaemon/Commands/SetRestartCommand.cs
+++ b/Updaemon/Commands/SetRestartCommand.cs
@@ -1,0 +1,102 @@
+using Updaemon.Interfaces;
+using Updaemon.Models;
+
+namespace Updaemon.Commands
+{
+    /// <summary>
+    /// Handles the 'set-restart' command to control whether a service is restarted after an update.
+    /// </summary>
+    public class SetRestartCommand : ICommand
+    {
+        private readonly IConfigManager _configManager;
+        private readonly IOutputWriter _outputWriter;
+
+        public SetRestartCommand(IConfigManager configManager, IOutputWriter outputWriter)
+        {
+            _configManager = configManager;
+            _outputWriter = outputWriter;
+        }
+
+        public string Name => "set-restart";
+
+        public string Description => "Set restart behavior after update (auto/manual)";
+
+        public string Usage => "updaemon set-restart <app-name> auto|manual";
+
+        public async Task<int> ExecuteAsync(string[] args, CancellationToken cancellationToken = default)
+        {
+            ArgumentParser parser = new ArgumentParser(args, _outputWriter);
+
+            if (!parser.ValidateMinimumArgs(2, Usage, out int errorCode))
+            {
+                return errorCode;
+            }
+
+            string localName = parser.GetPositional(0)!;
+            string mode = parser.GetPositional(1)!;
+
+            bool autoRestart;
+            switch (mode.ToLowerInvariant())
+            {
+                case "auto":
+                    autoRestart = true;
+                    break;
+                case "manual":
+                    autoRestart = false;
+                    break;
+                default:
+                    _outputWriter.WriteError($"Error: Invalid restart mode '{mode}'. Expected 'auto' or 'manual'.");
+                    _outputWriter.WriteLine($"Usage: {Usage}");
+                    return 1;
+            }
+
+            _outputWriter.WriteLine($"Setting restart behavior for '{localName}' to '{mode.ToLowerInvariant()}'");
+
+            try
+            {
+                await _configManager.SetAutoRestartAsync(localName, autoRestart, cancellationToken);
+            }
+            catch (InvalidOperationException ex)
+            {
+                _outputWriter.WriteError($"Error: {ex.Message}");
+                return 1;
+            }
+
+            _outputWriter.WriteLine("Restart behavior updated successfully");
+
+            // Auto-restart only affects services; CLI tools are never restarted.
+            RegisteredService? service = await _configManager.GetServiceAsync(localName, cancellationToken);
+            if (service != null && service.ServiceType == ServiceType.Cli)
+            {
+                _outputWriter.WriteLine("Note: this setting has no effect for CLI tools, which are never restarted.");
+            }
+
+            return 0;
+        }
+
+        public string GetDetailedHelp()
+        {
+            return """
+                Set-Restart Command
+
+                Usage:
+                  updaemon set-restart <app-name> auto|manual
+
+                Description:
+                  Controls whether a service is restarted after 'update' deploys a new version.
+
+                    auto    (default) Restart the service after deploying a new version.
+                    manual  Deploy the new version (download, repoint symlink, prune) but leave
+                            the running process untouched, so the application can restart on
+                            demand. The service keeps running the previous version until it
+                            restarts.
+
+                  Only meaningful for services; CLI tools are never restarted.
+
+                Examples:
+                  updaemon set-restart my-api manual
+                  updaemon set-restart my-api auto
+                """;
+        }
+    }
+}

--- a/Updaemon/Commands/UpdateCommand.cs
+++ b/Updaemon/Commands/UpdateCommand.cs
@@ -211,6 +211,12 @@ namespace Updaemon.Commands
                 {
                     _outputWriter.WriteLine("CLI tool updated successfully");
                 }
+                else if (!service.AutoRestart)
+                {
+                    // Deploy-only mode: leave the running process untouched so the application
+                    // can restart on demand.
+                    _outputWriter.WriteLine("New version deployed; restart skipped (restart=manual). The service keeps the previous version until it restarts.");
+                }
                 else
                 {
                     // Restart service
@@ -267,7 +273,9 @@ namespace Updaemon.Commands
                   are grouped by distribution plugin and updated efficiently.
 
                   For services, the underlying service (systemd on Linux, launchd on macOS)
-                  is restarted after updating.
+                  is restarted after updating, unless restart behavior is set to manual via
+                  'updaemon set-restart <app-name> manual' — in which case the new version is
+                  deployed but the running process is left untouched.
                   For CLI tools, the symlink chain resolves automatically to the new version.
 
                   After a successful deployment, old version directories are automatically

--- a/Updaemon/Configuration/ConfigManager.cs
+++ b/Updaemon/Configuration/ConfigManager.cs
@@ -94,6 +94,20 @@ namespace Updaemon.Configuration
             await SaveConfigAsync(config, cancellationToken);
         }
 
+        public async Task SetAutoRestartAsync(string localName, bool autoRestart, CancellationToken cancellationToken = default)
+        {
+            UpdaemonConfig config = await LoadConfigAsync(cancellationToken);
+
+            RegisteredService? service = config.Services.FirstOrDefault(s => s.LocalName == localName);
+            if (service == null)
+            {
+                throw new InvalidOperationException($"Service '{localName}' is not registered.");
+            }
+
+            service.AutoRestart = autoRestart;
+            await SaveConfigAsync(config, cancellationToken);
+        }
+
         public async Task<RegisteredService?> GetServiceAsync(string localName, CancellationToken cancellationToken = default)
         {
             UpdaemonConfig config = await LoadConfigAsync(cancellationToken);

--- a/Updaemon/Interfaces/IConfigManager.cs
+++ b/Updaemon/Interfaces/IConfigManager.cs
@@ -34,6 +34,12 @@ namespace Updaemon.Interfaces
         Task SetExecutableNameAsync(string localName, string? executableName, CancellationToken cancellationToken = default);
 
         /// <summary>
+        /// Updates whether an existing service is automatically restarted after an update.
+        /// When false, 'update' deploys the new version but leaves the running process untouched.
+        /// </summary>
+        Task SetAutoRestartAsync(string localName, bool autoRestart, CancellationToken cancellationToken = default);
+
+        /// <summary>
         /// Gets a registered service by local name.
         /// </summary>
         Task<RegisteredService?> GetServiceAsync(string localName, CancellationToken cancellationToken = default);

--- a/Updaemon/Models/RegisteredService.cs
+++ b/Updaemon/Models/RegisteredService.cs
@@ -31,6 +31,16 @@ namespace Updaemon.Models
         /// Defaults to Service for backwards compatibility with existing configs.
         /// </summary>
         public ServiceType ServiceType { get; set; } = ServiceType.Service;
+
+        /// <summary>
+        /// Whether the service is automatically restarted after a new version is deployed.
+        /// When false, 'update' deploys the new version (download, repoint symlink, prune) but
+        /// leaves the running process untouched, letting the application restart on demand.
+        /// Only meaningful for Service-type entries; CLI tools are never restarted.
+        /// Defaults to true for backwards compatibility — a missing field in an existing config
+        /// deserializes to true.
+        /// </summary>
+        public bool AutoRestart { get; set; } = true;
     }
 }
 

--- a/Updaemon/Program.cs
+++ b/Updaemon/Program.cs
@@ -89,6 +89,7 @@ namespace Updaemon
             services.AddTransient<UpdateCommand>();
             services.AddTransient<SetRemoteCommand>();
             services.AddTransient<SetExecNameCommand>();
+            services.AddTransient<SetRestartCommand>();
             services.AddTransient<DistInstallCommand>();
             services.AddTransient<DistUpdateCommand>();
             services.AddTransient<DistListCommand>();


### PR DESCRIPTION
## Why?
Closes #17. `updaemon update` always restarted a service after deploying a new
version. For some services it's preferable to deploy the new version but leave
the running process untouched, so the application can decide *when* to apply the
update (e.g. show a "restart to apply" prompt and exit gracefully under
`Restart=always` / `KeepAlive=true`).

## What?
- New `RegisteredService.AutoRestart` flag (default `true`), serialized in `config.json`.
- New `updaemon set-restart <app-name> auto|manual` command to toggle it (mirrors `set-remote` / `set-exec-name`), with a `SetAutoRestartAsync` config-manager method.
- In manual mode, `update` runs the full deploy pipeline (download, repoint `current`, prune) but skips both restart and start, emitting a clear log line.
- `list` shows `Restart: auto|manual` for service-type entries.
- README and command help updated; tests cover the manual path, command parsing, list display, and the missing-field-defaults-to-true behavior.

## Challenges
- **Backwards compatibility:** existing configs have no `autoRestart` field. Relying on the source-gen serializer's behavior (parameterless ctor runs the `= true` initializer, missing JSON fields don't overwrite it) means old configs deserialize to `true` with no migration — covered by a dedicated test.
- **Stopped-service semantics:** chose to skip *both* restart and start in manual mode ("don't touch the process"), rather than only skipping restart.
- **CLI surface:** used `auto|manual` rather than `true|false` to keep the internal bool out of the user-facing contract; CLI-type entries get an informational note since they're never restarted.